### PR TITLE
Add initial version of a nix shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ output
 docs
 env
 tsconfig.tsbuildinfo
-lerna-debug.log
 .yarn/*
 !.yarn/patches
 !.yarn/plugins

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,18 @@
+# Marlowe TS-SDK
+TODO
+
+# Testing
+
+
+In order to run the E2E tests you need to create a `env/.env.test` file that points to a working version of the marlowe runtime and a working Blockfrost instance and a faucet PK
+
+TODO: explain how to get the Faucet PK
+
+
+```
+MARLOWE_WEB_SERVER_URL="http://<path-to-runtime>:33294/"
+BLOCKFROST_PROJECT_ID="<blockfrost-id>"
+BLOCKFROST_URL="https://cardano-preprod.blockfrost.io/api/v0"
+NETWORK_ID=Preprod
+BANK_PK_HEX='<pk>'
+```

--- a/Readme.md
+++ b/Readme.md
@@ -1,13 +1,12 @@
 # Marlowe TS-SDK
+
 TODO
 
-# Testing
-
+## Testing
 
 In order to run the E2E tests you need to create a `env/.env.test` file that points to a working version of the marlowe runtime and a working Blockfrost instance and a faucet PK
 
 TODO: explain how to get the Faucet PK
-
 
 ```
 MARLOWE_WEB_SERVER_URL="http://<path-to-runtime>:33294/"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,329 @@
+{
+  "nodes": {
+    "blank": {
+      "locked": {
+        "lastModified": 1625557891,
+        "narHash": "sha256-O8/MWsPBGhhyPoPLHZAuoZiiHo9q6FLlEeIDEXuj6T4=",
+        "owner": "divnix",
+        "repo": "blank",
+        "rev": "5a5d2684073d9f563072ed07c871d577a6c614a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "blank",
+        "type": "github"
+      }
+    },
+    "call-flake": {
+      "locked": {
+        "lastModified": 1687380775,
+        "narHash": "sha256-bmhE1TmrJG4ba93l9WQTLuYM53kwGQAjYHRvHOeuxWU=",
+        "owner": "divnix",
+        "repo": "call-flake",
+        "rev": "74061f6c241227cd05e79b702db9a300a2e4131a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "call-flake",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1688380630,
+        "narHash": "sha256-8ilApWVb1mAi4439zS3iFeIT0ODlbrifm/fegWwgHjA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "f9238ec3d75cefbb2b42a44948c4e8fb1ae9a205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "dmerge": {
+      "inputs": {
+        "haumea": [
+          "std",
+          "haumea"
+        ],
+        "nixlib": [
+          "std",
+          "haumea",
+          "nixpkgs"
+        ],
+        "yants": [
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1686862774,
+        "narHash": "sha256-ojGtRQ9pIOUrxsQEuEPerUkqIJEuod9hIflfNkY+9CE=",
+        "owner": "divnix",
+        "repo": "dmerge",
+        "rev": "9f7f7a8349d33d7bd02e0f2b484b1f076e503a96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "ref": "0.2.1",
+        "repo": "dmerge",
+        "type": "github"
+      }
+    },
+    "haumea": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1685133229,
+        "narHash": "sha256-FePm/Gi9PBSNwiDFq3N+DWdfxFq0UKsVVTJS3cQPn94=",
+        "owner": "nix-community",
+        "repo": "haumea",
+        "rev": "34dd58385092a23018748b50f9b23de6266dffc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v0.2.2",
+        "repo": "haumea",
+        "type": "github"
+      }
+    },
+    "incl": {
+      "inputs": {
+        "nixlib": [
+          "std",
+          "haumea",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1669263024,
+        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677383253,
+        "narHash": "sha256-UfpzWfSxkfXHnb4boXZNaKsAcUrZT9Hw+tao1oZxd08=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9952d6bc395f5841262b006fbace8dd7e143b634",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681001314,
+        "narHash": "sha256-5sDnCLdrKZqxLPK4KA8+f4A3YKO/u6ElpMILvX0g72c=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "367c0e1086a4eb4502b24d872cea2c7acdd557f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1675940568,
+        "narHash": "sha256-epG6pOT9V0kS+FUqd7R6/CWkgnZx2DMT5Veqo+y6G3c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6ccc4a59c3f1b56d039d93da52696633e641bc71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nosys": {
+      "locked": {
+        "lastModified": 1668010795,
+        "narHash": "sha256-JBDVBnos8g0toU7EhIIqQ1If5m/nyBqtHhL3sicdPwI=",
+        "owner": "divnix",
+        "repo": "nosys",
+        "rev": "feade0141487801c71ff55623b421ed535dbdefa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nosys",
+        "type": "github"
+      }
+    },
+    "paisano": {
+      "inputs": {
+        "call-flake": "call-flake",
+        "nixpkgs": [
+          "std",
+          "nixpkgs"
+        ],
+        "nosys": "nosys",
+        "yants": [
+          "std",
+          "yants"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688099125,
+        "narHash": "sha256-j6LMz00orEKZrQb14wRRw7kMLm+aj7zBJt05AY4UcRI=",
+        "owner": "paisano-nix",
+        "repo": "core",
+        "rev": "10270dc46532c947de473ee88c8f5a3346a396fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "repo": "core",
+        "type": "github"
+      }
+    },
+    "paisano-tui": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681847764,
+        "narHash": "sha256-mdd7PJW1BZvxy0cIKsPfAO+ohVl/V7heE5ZTAHzTdv8=",
+        "owner": "paisano-nix",
+        "repo": "tui",
+        "rev": "3096bad91cae73ab8ab3367d31f8a143d248a244",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paisano-nix",
+        "ref": "0.1.1",
+        "repo": "tui",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": [
+          "std",
+          "nixpkgs"
+        ],
+        "std": "std"
+      }
+    },
+    "std": {
+      "inputs": {
+        "arion": [
+          "std",
+          "blank"
+        ],
+        "blank": "blank",
+        "devshell": "devshell",
+        "dmerge": "dmerge",
+        "haumea": "haumea",
+        "incl": "incl",
+        "makes": [
+          "std",
+          "blank"
+        ],
+        "microvm": [
+          "std",
+          "blank"
+        ],
+        "n2c": [
+          "std",
+          "blank"
+        ],
+        "nixago": [
+          "std",
+          "blank"
+        ],
+        "nixpkgs": "nixpkgs_3",
+        "paisano": "paisano",
+        "paisano-tui": "paisano-tui",
+        "terranix": [
+          "std",
+          "blank"
+        ],
+        "yants": "yants"
+      },
+      "locked": {
+        "lastModified": 1689337213,
+        "narHash": "sha256-qa0B38ihDW1MuAshwgvlbkk3CgheWlvYr35oMpDrxJs=",
+        "owner": "divnix",
+        "repo": "std",
+        "rev": "17dc4eb9587517397dad00617b020769fece3cfe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "std",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "yants": {
+      "inputs": {
+        "nixpkgs": [
+          "std",
+          "haumea",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1686863218,
+        "narHash": "sha256-kooxYm3/3ornWtVBNHM3Zh020gACUyFX2G0VQXnB+mk=",
+        "owner": "divnix",
+        "repo": "yants",
+        "rev": "8f0da0dba57149676aa4817ec0c880fbde7a648d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "yants",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+# flake.nix template from the STD Library
+{
+  description = "Marlowe ts-sdk";
+
+  inputs = {
+    std.url = "github:divnix/std";
+    nixpkgs.follows = "std/nixpkgs";
+    std.inputs.devshell.url = "github:numtide/devshell";
+  };
+
+  outputs = { std, self, ...} @ inputs: std.growOn {
+    inherit inputs;
+    # 1. Each folder inside `cellsFrom` becomes a "Cell"
+    #    Run for example: 'mkdir nix/mycell'
+    # 2. Each <block>.nix or <block>/default.nix within it becomes a "Cell Block"
+    #    Run for example: '$EDITOR nix/mycell/packages.nix' - see example content below
+    cellsFrom = ./nix;
+    # 3. Only blocks with these names [here: "packages" & "shells"] are picked up by Standard
+    #    It's a bit like the output type system of your flake project (hint: CLI & TUI!!)
+    cellBlocks = with std.blockTypes; [
+      (installables "packages" {ci.build = true;})
+      (devshells "shells" {ci.build = true;})
+    ];
+  }
+  # 4. Run 'nix run github:divnix/std'
+  # 'growOn' ... Soil:
+  #  - here, compat for the Nix CLI
+  #  - but can use anything that produces flake outputs (e.g. flake-parts or flake-utils)
+  # 5. Run: nix run .
+  {
+    devShells = std.harvest self ["ts-sdk" "shells"];
+    packages = std.harvest self ["ts-sdk" "packages"];
+  };
+}

--- a/nix/ts-sdk/packages.nix
+++ b/nix/ts-sdk/packages.nix
@@ -1,0 +1,4 @@
+{inputs, cell}: {
+  inherit (inputs.nixpkgs) hello;
+  default = cell.packages.hello;
+}

--- a/nix/ts-sdk/shells.nix
+++ b/nix/ts-sdk/shells.nix
@@ -1,0 +1,40 @@
+{
+  inputs,
+  cell,
+}: let
+  inherit (inputs.std) std lib;
+  inherit (inputs) nixpkgs;
+
+  # l = nixpkgs.lib // builtins;
+
+  dev = lib.dev.mkShell {
+    packages = with nixpkgs; [
+      pkg-config
+      nodejs
+      yarn
+    ];
+
+    env = [
+
+    ];
+
+    commands =
+      [
+        {
+          package = nixpkgs.nodejs;
+          category = "JavaScript";
+        }
+        {
+          package = nixpkgs.yarn;
+          category = "JavaScript";
+        }
+        {
+          package = std.cli.default;
+          category = "std";
+        }
+      ];
+  };
+in {
+  inherit dev;
+  default = dev;
+}


### PR DESCRIPTION
This PR just adds a nix shell trough flakes so that you can use the project without having a global version of node and yarn.

To test just do 
```
$ nix develop
```

And check that you can build the project using `npm run build`