### PR TITLE
PLT-6928: Autogeneration of documentation

### DIFF
--- a/.github/workflows/post-integration.yaml
+++ b/.github/workflows/post-integration.yaml
@@ -1,0 +1,44 @@
+name: Post-integration
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v3
+
+      - name: 🧰 Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: 🧰 Setup nix
+        uses: cachix/install-nix-action@v22
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🔨 Build Docs
+        run: |
+          nix develop --show-trace --command bash -c "npm i && npm run build && npm run docs"
+
+      - name: 📘 Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: './docs'
+
+      - name: 📘 Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/Readme.md
+++ b/Readme.md
@@ -45,3 +45,36 @@ BLOCKFROST_URL="https://cardano-preprod.blockfrost.io/api/v0"
 NETWORK_ID=Preprod
 BANK_PK_HEX='<pk>'
 ```
+
+### Documentation
+
+> ⚠ You need to [build the packages](#build) before you can compile the documentation!
+
+To compile all documentation
+
+```
+$ npm run docs
+```
+
+Documentation is built with [TypeDoc](https://typedoc.org), published through [GitHub Pages](https://pages.github.com), and hosted at https://input-output-hk.github.io/marlowe-ts-sdk
+
+Each sub project needs a `typedoc.json` file in the sub project root directory as specified in the `workspaces` field in `./packages.json`. For example, there's some project "some-project" specified:
+
+```json
+// ./packages.json
+{
+  ...,
+  "workspaces": ["./path/to/some-project"]
+}
+```
+
+There needs to be a `typedoc.json` in `./path/to/some-project` and it needs properties along the lines of this example:
+
+```json
+// ./path/to/some-project/typedoc.json
+{
+  "entryPointStrategy": "expand",
+  "entryPoints": ["./src"],
+  "tsconfig": "./tsconfig.json"
+}
+```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "tsc --build && rollup --config rollup/legacy-runtime-esm.config.mjs",
     "clean": "npm run clean --workspaces && shx rm -rf dist",
-    "test": "npm run test --workspaces"
+    "test": "npm run test --workspaces",
+    "docs": "typedoc ."
   },
   "workspaces": [
     "packages/legacy-adapter",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "shx": "^0.3.3",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
+    "typedoc": "^0.24.8",
     "typescript": "^4.9.5",
     "typescript-language-server": "^3.1.0"
   },

--- a/packages/language/core/v1/typedoc.json
+++ b/packages/language/core/v1/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "entryPointStrategy": "expand",
+  "entryPoints": ["./src/semantics"],
+  "tsconfig": "./src/tsconfig.json"
+}

--- a/packages/legacy-adapter/typedoc.json
+++ b/packages/legacy-adapter/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "entryPointStrategy": "expand",
+  "entryPoints": ["./src"],
+  "tsconfig": "./src/tsconfig.json"
+}

--- a/packages/legacy-runtime/typedoc.json
+++ b/packages/legacy-runtime/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "entryPointStrategy": "expand",
+  "entryPoints": ["./src"],
+  "tsconfig": "./src/tsconfig.json"
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "entryPointStrategy": "packages",
+  "out": "./docs",
+  "readme": "none"
+}


### PR DESCRIPTION
## Summary
- Installs TypeDoc in the project npm `devDependencies`
- Configures TypeDoc
- Configures GitHub Actions to compile documentation and publish artifacts with GitHub Pages to https://input-output-hk.github.io/marlowe-ts-sdk
- Adds a section to ./Readme.md on how to compile the documentation and how to work with it for future packages in this project