### PR TITLE
PLT-6942: Changelog management

### DIFF
--- a/.github/workflows/check-changelog.yaml
+++ b/.github/workflows/check-changelog.yaml
@@ -1,0 +1,54 @@
+name: Check changelog
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v3.3.0
+
+      - name: 🧰 Find Changed Files in changelog.d
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+        with:
+          files: './changelog.d/**'
+
+      - name: 🔨 Enforce New File or 'No Changelog Required' Label
+        uses: actions/github-script@v6
+        # Don't require changelogs for draft PRs:
+        if: github.event.pull_request.draft == false
+        with:
+          script: | 
+            function shouldCheckChangelog() {
+              return !${{ contains(github.event.pull_request.labels.*.name, 'No Changelog Required') }}
+            }
+
+            function getNewChangelogFiles() {
+              const newFiles = '${{ steps.changed-files.outputs.added_files }}'.trim().split(' ')
+              // We check that added_files is the singleton array containing the empty string.
+              // This is probably a bug in tj-actions/changed-files
+              return newFiles.length === 1 && newFiles[0] === "" ? [] : newFiles
+            }
+
+            function checkChangelog() {
+              const newFiles = getNewChangelogFiles()
+              if (newFiles.length === 0) {
+                core.info("No files were added by this PR in any of the **/changelog.d directories.")
+                core.info("Either commit a new file, or add the label 'No Changelog Required' to your PR.")
+                core.setFailed("Changelog check failed.")
+              } else
+                core.info(`The following changelog files were added by this PR:\n${newFiles}`)
+            }
+
+            if (shouldCheckChangelog())
+              checkChangelog()
+            else
+              core.info("PR contains the label 'No Changelog Required', skipping changelog check.")

--- a/.github/workflows/post-integration.yaml
+++ b/.github/workflows/post-integration.yaml
@@ -1,7 +1,9 @@
 name: Post integration
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/post-integration.yaml
+++ b/.github/workflows/post-integration.yaml
@@ -1,4 +1,4 @@
-name: Post-integration
+name: Post integration
 
 on:
   pull_request:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: 🧰 Setup Pages
         uses: actions/configure-pages@v3

--- a/Readme.md
+++ b/Readme.md
@@ -87,3 +87,15 @@ There needs to be a `typedoc.json` in `./path/to/some-project` and it needs prop
   "tsconfig": "./tsconfig.json"
 }
 ```
+
+### Changelogs
+
+This project manages its changelog with [scriv](https://github.com/nedbat/scriv). PRs are automatically checked to see if there's a new entry in the `./changelog.d` folder. If a PR doesn't need a changelog entry, a `No Changelog Required` label can be added to disable the check.
+
+Create a new changelog entry template with
+
+```
+$ scriv create
+```
+
+edit the new file with appropriate content for your PR and commit it. Read [the documentation for scriv](https://scriv.readthedocs.io/en) to learn more about how to use this tool.

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,3 @@
+[scriv]
+format = md
+version = 1.0.0.0

--- a/nix/ts-sdk/shells.nix
+++ b/nix/ts-sdk/shells.nix
@@ -12,6 +12,7 @@
       pkg-config
       nodejs
       yarn
+      scriv
     ];
 
     env = [


### PR DESCRIPTION
### Summary
- Sets up CI to require a changelog or a `No Changelog Required` label on PR.
- Adds the [scriv](https://github.com/nedbat/scriv) CLI program to the `nix develop` shell.
- Documents how developers may use scriv to add their own changelog entries.
- Fixes a bug in the CI for deploying documentation where it should only deploy docs when `main` branch is updated