### PR TITLE
PLT-7501 Partially remove fp-ts from rest client

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Official Links
 
 # Overview
 
-The **Marlowe TS-SDK** is a suite of *TypeScript/JavaScript* libraries for developing Web-Dapp in the Cardano Blockchain using Marlowe Technologies.
+The **Marlowe TS-SDK** is a suite of _TypeScript/JavaScript_ libraries for developing Web-Dapp in the Cardano Blockchain using Marlowe Technologies.
 
 It is composed of several npm packages documented in the [API reference](https://input-output-hk.github.io/marlowe-ts-sdk/) page.
 

--- a/changelog.d/20230925_203338_hrajchert_PLT_7501_remove_fpts_from_rest_client.md
+++ b/changelog.d/20230925_203338_hrajchert_PLT_7501_remove_fpts_from_rest_client.md
@@ -1,0 +1,3 @@
+### @marlowe.io/runtime-rest-client
+
+- BREAKING CHANGE: Replaced mkRestClient interface for a flat API that resembles the backend documentation structure.

--- a/doc/howToDevelop.md
+++ b/doc/howToDevelop.md
@@ -127,12 +127,12 @@ And in a separate project you can install the tarballs using a file url when dec
 ```json
 {
   "dependencies": {
-    "@marlowe.io/runtime-lifecycle": "file:<path-to-dist>/marlowe.io-runtime-lifecycle-0.2.0-alpha-1.tgz",
-    "@marlowe.io/runtime-rest-client": "file:<path-to-dist>/marlowe.io-runtime-rest-client-0.2.0-alpha-1.tgz",
-    "@marlowe.io/adapter": "file:<path-to-dist>/marlowe.io-adapter-0.2.0-alpha-1.tgz",
-    "@marlowe.io/runtime-core": "file:<path-to-dist>/marlowe.io-runtime-core-0.2.0-alpha-1.tgz",
-    "@marlowe.io/language-core-v1": "file:<path-to-dist>/marlowe.io-language-core-v1-0.2.0-alpha-1.tgz",
-    "@marlowe.io/wallet": "file:<path-to-dist>/marlowe.io-wallet-0.2.0-alpha-1.tgz"
+    "@marlowe.io/runtime-lifecycle": "file:<path-to-dist>/marlowe.io-runtime-lifecycle-0.2.0-alpha-2.tgz",
+    "@marlowe.io/runtime-rest-client": "file:<path-to-dist>/marlowe.io-runtime-rest-client-0.2.0-alpha-2.tgz",
+    "@marlowe.io/adapter": "file:<path-to-dist>/marlowe.io-adapter-0.2.0-alpha-2.tgz",
+    "@marlowe.io/runtime-core": "file:<path-to-dist>/marlowe.io-runtime-core-0.2.0-alpha-2.tgz",
+    "@marlowe.io/language-core-v1": "file:<path-to-dist>/marlowe.io-language-core-v1-0.2.0-alpha-2.tgz",
+    "@marlowe.io/wallet": "file:<path-to-dist>/marlowe.io-wallet-0.2.0-alpha-2.tgz"
   }
 }
 ```

--- a/doc/modules-system.md
+++ b/doc/modules-system.md
@@ -1,13 +1,14 @@
 # Modules System
+
 Javascript didn't have an official module support until ESM was introduced in 2015, in 2020 all the major browsers implemented it. By 2023, the community is still in the process of migrating from CommonJS, UMD, etc to ESM, and different tools and libraries have varying support for it.
 
 ## ESM
+
 The Marlowe SDK is built using ESM modules but one of its dependencies (fp-ts) doesn't [correctly implement it](https://github.com/gcanti/fp-ts/issues/1777) in its current version. For that reason, we use [rollup](https://rollupjs.org/) to generate a ESM bundle that includes fp-ts. To ease development, we also generate [import maps](https://github.com/WICG/import-maps#import-maps) that tell the browser where to find the different modules.
 
 In most packages documentation you'll find something like:
 
 ```html
-
 <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
 <script type="module">
   import * as wallet from "@marlowe.io/wallet";
@@ -20,6 +21,7 @@ If you are using a bundler you don't need the import map as each `package.json``
 > NOTE: Because of how `fp-ts` is bundled, it is included (and tree-shaked) in all the SDK bundled packages, so using your own bundling step can help you reduce the size of the downloaded code.
 
 ## CommonJS
+
 > NOTE: [[CommonJS exports problem]]
 
 This repository configures how to be imported using `ESM` and `CJS` modules, but the latter is currently not working because one of the dependencies [does not support CJS](https://github.com/spacebudz/lucid#compatibility). We need to re-assess if we can use an alternative that does support CJS so that it is easier to import the SDK from older setups.

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694858246,
-        "narHash": "sha256-zcKnlTrMspD6YUgN1VyKMKSZ5Few3LCyDyBz3wtGPJQ=",
+        "lastModified": 1695195896,
+        "narHash": "sha256-pq9q7YsGXnQzJFkR5284TmxrLNFc0wo4NQ/a5E93CQU=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "f26c2e05cd766be3750dd3d6e276650a1eab4c61",
+        "rev": "05d40d17bf3459606316e3e9ec683b784ff28f16",
         "type": "github"
       },
       "original": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marlowe-ts-sdk",
-  "version": "0.2.0-alpha-1",
+  "version": "0.2.0-alpha-2",
   "description": "Marlowe Runtime SDK for building and managing Marlowe Contracts",
   "engines": {
     "node": ">=14.20.1"

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marlowe.io/adapter",
-  "version": "0.2.0-alpha-1",
+  "version": "0.2.0-alpha-2",
   "description": "Infrastruture Supporting SubDomains libraries",
   "repository": "https://github.com/input-output-hk/marlowe-ts-sdk",
   "publishConfig": {

--- a/packages/adapter/src/http.ts
+++ b/packages/adapter/src/http.ts
@@ -6,6 +6,7 @@ import { MarloweJSON } from "@marlowe.io/adapter/codec";
 const getOnlyData = TE.bimap(
   (e: unknown) =>
     e instanceof Error ? e : new Error(MarloweJSON.stringify(e)),
+  // FIXME: This should be `unknown` rather than any, but it is causing multiple compile errors
   (v: AxiosResponse): any => v.data
 );
 

--- a/packages/api.md
+++ b/packages/api.md
@@ -1,4 +1,4 @@
-The **Marlowe TS-SDK** is a suite of *TypeScript/JavaScript* libraries for developing Web-Dapp in the Cardano Blockchain using Marlowe Technologies.
+The **Marlowe TS-SDK** is a suite of _TypeScript/JavaScript_ libraries for developing Web-Dapp in the Cardano Blockchain using Marlowe Technologies.
 
 It is composed of the following packages:
 

--- a/packages/language/core/v1/package.json
+++ b/packages/language/core/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marlowe.io/language-core-v1",
-  "version": "0.2.0-alpha-1",
+  "version": "0.2.0-alpha-2",
   "description": "Library to manipulate Marlowe Core contracts",
   "repository": "https://github.com/input-output-hk/marlowe-ts-sdk",
   "publishConfig": {

--- a/packages/runtime/client/rest/Readme.md
+++ b/packages/runtime/client/rest/Readme.md
@@ -13,12 +13,10 @@ The `@marlowe.io/runtime-rest-client` package is [released as an ESM module](htt
 ```html
 <html>
   <body>
-    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js">
-    </script>
+    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
     <script type="module">
       import { mkRestClient } from "@marlowe.io/runtime-rest-client";
       // TODO
-
     </script>
   </body>
 </html>

--- a/packages/runtime/client/rest/Readme.md
+++ b/packages/runtime/client/rest/Readme.md
@@ -1,3 +1,25 @@
-# @marlowe.io/runtime-rest-client
+# Description
 
-TODO
+The `runtime-rest-client` package provides a JS API to interact with the [runtime REST API](https://docs.marlowe.iohk.io/api/introduction). It is intended to work with version `0.0.5` of the API.
+
+The main {@link index | module} exposes the {@link index.mkFlatRestClient} function, which returns an instance of a {@link index.RuntimeFlatApi}.
+
+## Getting started
+
+The `@marlowe.io/runtime-rest-client` package is [released as an ESM module](https://github.com/input-output-hk/marlowe-ts-sdk/blob/main/doc/modules-system.md) and can be used with a modern bundler or imported directly in the browser (without any bundler) as long as you use an import map.
+
+### Browser
+
+```html
+<html>
+  <body>
+    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js">
+    </script>
+    <script type="module">
+      import { mkRestClient } from "@marlowe.io/runtime-rest-client";
+      // TODO
+
+    </script>
+  </body>
+</html>
+```

--- a/packages/runtime/client/rest/Readme.md
+++ b/packages/runtime/client/rest/Readme.md
@@ -2,7 +2,7 @@
 
 The `runtime-rest-client` package provides a JS API to interact with the [runtime REST API](https://docs.marlowe.iohk.io/api/introduction). It is intended to work with version `0.0.5` of the API.
 
-The main {@link index | module} exposes the {@link index.mkFlatRestClient} function, which returns an instance of a {@link index.RuntimeFlatApi}.
+The main {@link index | module} exposes the {@link index.mkRestClient} function, which returns an instance of a {@link index.RestAPI}.
 
 ## Getting started
 

--- a/packages/runtime/client/rest/package.json
+++ b/packages/runtime/client/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marlowe.io/runtime-rest-client",
-  "version": "0.2.0-alpha-1",
+  "version": "0.2.0-alpha-2",
   "description": "Client of Runtime REST API",
   "repository": "https://github.com/input-output-hk/marlowe-ts-sdk",
   "publishConfig": {
@@ -44,9 +44,9 @@
     "./contract/*": "./dist/esm/contract/*.js"
   },
   "dependencies": {
-    "@marlowe.io/adapter": "0.2.0-alpha-1",
-    "@marlowe.io/language-core-v1": "0.2.0-alpha-1",
-    "@marlowe.io/runtime-core": "0.2.0-alpha-1",
+    "@marlowe.io/adapter": "0.2.0-alpha-2",
+    "@marlowe.io/language-core-v1": "0.2.0-alpha-2",
+    "@marlowe.io/runtime-core": "0.2.0-alpha-2",
     "qs": "^6.11.2",
     "fp-ts": "^2.13.1",
     "io-ts": "2.2.20",

--- a/packages/runtime/client/rest/src/contract/details.ts
+++ b/packages/runtime/client/rest/src/contract/details.ts
@@ -16,10 +16,40 @@ import {
   PolicyId,
 } from "@marlowe.io/runtime-core";
 
+// QUESTION: Where do we have global documentation about how Roles and payouts work?
+/**
+ * Identifies a payout that can be withdrawn from a contract.
+ * @see The {@link Payout:var | dynamic validator} for this type.
+ * @interface
+ */
 export type Payout = t.TypeOf<typeof Payout>;
-export const Payout = t.type({ payoutId: TxOutRef, role: RoleName });
 
+/**
+ * This is a {@link !io-ts-usage | Dynamic type validator} for a {@link Payout:type}.
+ * @category Validator
+ */
+export const Payout = t.type({
+  /**
+   * A reference to the payout script that contains the assets to be withdrawn.
+   */
+  payoutId: TxOutRef,
+  /**
+   * The {@link RoleName} of the participant that has the unclaimed Payout.
+   */
+  role: RoleName
+});
+
+/**
+ * Represents the response of the {@link index.ContractsAPI | Get contract by id } endpoint
+ * @see The {@link ContractDetails:var | dynamic validator} for this type.
+ * @interface
+ */
 export type ContractDetails = t.TypeOf<typeof ContractDetails>;
+
+/**
+ * This is a {@link !io-ts-usage | Dynamic type validator} for the {@link ContractDetails:type}.
+ * @category Validator
+ */
 export const ContractDetails = t.type({
   contractId: ContractId,
   roleTokenMintingPolicyId: PolicyId,

--- a/packages/runtime/client/rest/src/contract/details.ts
+++ b/packages/runtime/client/rest/src/contract/details.ts
@@ -36,15 +36,15 @@ export const Payout = t.type({
   /**
    * The {@link RoleName} of the participant that has the unclaimed Payout.
    */
-  role: RoleName
+  role: RoleName,
 });
 
 /**
- * Represents the response of the {@link index.ContractsAPI | Get contract by id } endpoint
+ * Represents the response of the {@link index.RestAPI#getContractById | Get contract by id } endpoint
  * @see The {@link ContractDetails:var | dynamic validator} for this type.
  * @interface
  */
-export type ContractDetails = t.TypeOf<typeof ContractDetails>;
+export interface ContractDetails extends t.TypeOf<typeof ContractDetails> {}
 
 /**
  * This is a {@link !io-ts-usage | Dynamic type validator} for the {@link ContractDetails:type}.

--- a/packages/runtime/client/rest/src/contract/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/contract/endpoints/collection.ts
@@ -25,23 +25,57 @@ import {
   unAddressBech32,
   unTxOutRef,
   AddressesAndCollaterals,
+  AddressBech32,
+  TxOutRef,
 } from "@marlowe.io/runtime-core";
 
-import { Header } from "../header.js";
+import { ContractHeader } from "../header.js";
 import { RolesConfig } from "../role.js";
 
 import { ContractId } from "@marlowe.io/runtime-core";
 
+/**
+ * @category GetContractsResponse
+ */
 export interface ContractsRange
   extends Newtype<{ readonly ContractsRange: unique symbol }, string> {}
+
+/**
+ * @category GetContractsResponse
+ */
 export const ContractsRange = fromNewtype<ContractsRange>(t.string);
 export const unContractsRange = iso<ContractsRange>().unwrap;
 export const contractsRange = iso<ContractsRange>().wrap;
 
+/**
+ * Request options for the {@link index.RuntimeFlatApi#getContracts | Get contracts } endpoint
+ * @category Endpoints
+ */
+export type GetContractsRequest = {
+  /**
+   * Optional pagination request. Note that when you call {@link index.RuntimeFlatApi#getContracts | Get contracts }
+   * the response includes the next and previous range headers.
+   */
+  // QUESTION: @Jamie, is this supposed to be constructed by the user? or solely from other endpoints?
+  range?: ContractsRange;
+  /**
+   * Optional tags to filter the contracts by.
+   */
+  // QUESTION: @Jamie or @N.H, a tag is marked as string, but when creating a contract you need to pass a key and a value, what is this
+  //           string supposed to be? I have some contracts with tag "{SurveyContract: CryptoPall2023}" that I don't know how to search for.
+  tags?: Tag[];
+  // FIXME: create ticket to Add RoleCurrency filter
+};
+
 export type GETHeadersByRange = (
   rangeOption: O.Option<ContractsRange>
-) => (tags: Tag[]) => TE.TaskEither<Error | DecodingError, GETByRangeResponse>;
+) => (
+  tags: Tag[]
+) => TE.TaskEither<Error | DecodingError, GetContractsResponse>;
 
+/**
+ * @see {@link https://docs.marlowe.iohk.io/api/get-contracts}
+ */
 export const getHeadersByRangeViaAxios: (
   axiosInstance: AxiosInstance
 ) => GETHeadersByRange = (axiosInstance) => (rangeOption) => (tags) =>
@@ -90,7 +124,7 @@ export const GETByRangeRawResponse = t.type({
     results: t.array(
       t.type({
         links: t.type({ contract: t.string, transactions: t.string }),
-        resource: Header,
+        resource: ContractHeader,
       })
     ),
   }),
@@ -98,19 +132,108 @@ export const GETByRangeRawResponse = t.type({
   nextRange: optionFromNullable(ContractsRange),
 });
 
-export type GETByRangeResponse = t.TypeOf<typeof GETByRangeResponse>;
-export const GETByRangeResponse = t.type({
-  headers: t.array(Header),
+/**
+ * Represents the response of the {@link index.RuntimeFlatApi | Get contracts } endpoint
+ * @see The {@link GetContractsResponse:var | dynamic validator} for this type.
+ * @category GetContractsResponse
+ */
+export interface GetContractsResponse
+  extends t.TypeOf<typeof GetContractsResponse> {
+  // NOTE: by repeating this the typedoc is generated with the link instead of embedding
+  //       the definition
+  // headers: ContractHeader[];
+}
+
+/**
+ * This is a {@link !io-ts-usage | Dynamic type validator} for {@link GetContractsResponse:type}.
+ * @category Validator
+ * @category GetContractsResponse
+ */
+export const GetContractsResponse = t.type({
+  /**
+   * An array of {@link ContractHeader:type}
+   */
+  // DISCUSSION: Rename to "contracts" or "results"
+  headers: t.array(ContractHeader),
+  // TODO: Change Option for nullable
+  // QUESTION: @Jamie, how are these sorted? previousRange means newer contracts? recent activity?
+  /**
+   * The previous range header. This is used for pagination.
+   */
   previousRange: optionFromNullable(ContractsRange),
+  /**
+   * The next range header. This is used for pagination.
+   */
   nextRange: optionFromNullable(ContractsRange),
+  // TODO: Add current range
 });
+
+/**
+ * Request options for the {@link index.RuntimeFlatApi#createContract | Create contract } endpoint
+ * @category Endpoints
+ */
+export type CreateContractRequest = {
+  // FIXME: create ticket to add stake address
+  // stakeAddress: void;
+  /**
+   * Address to send any remainders of the transaction.
+   * @see {@link @marlowe.io/wallet.WalletAPI#getChangeAddress}
+   * @see {@link https://academy.glassnode.com/concepts/utxo#change-in-utxo-models}
+   */
+  changeAddress: AddressBech32;
+  /**
+   * TODO: Document
+   */
+  // Got this name from AddressesAndCollaterals.
+  // TODO: @Jamie, @N.H, lets unify name. Plain `x-Address` is not very descriptive, seems singular
+  usedAddresses?: AddressBech32[];
+  /**
+   * TODO: Document
+   */
+  collateralUTxOs?: TxOutRef[];
+  /**
+   * The contract to create
+   */
+  contract: Contract;
+  /**
+   * An object containing metadata about the contract
+   */
+  // TODO: Add link to example of metadata
+  // QUESTION: Jamie, why is this required?
+  metadata: Metadata;
+  /**
+   * When we create a contract we need to specify the minimum amount of ADA that we need to deposit. This
+   * is a cardano ledger restriction to avoid spamming the network
+   */
+  // TODO: Find link with better explanation
+  minUTxODeposit: number;
+
+  // TODO: Comment this
+  roles?: RolesConfig;
+  /**
+   * An object of tags where the key is the tag name and the value is the tag content
+   */
+  tags: Tags;
+
+  /**
+   * The validator version to use.
+   */
+  version: MarloweVersion;
+
+};
 
 export type POST = (
   postContractsRequest: PostContractsRequest,
   addressesAndCollaterals: AddressesAndCollaterals
 ) => TE.TaskEither<Error | DecodingError, ContractTextEnvelope>;
 
+/**
+ * @hidden
+ */
 export type PostContractsRequest = t.TypeOf<typeof PostContractsRequest>;
+/**
+ * @hidden
+ */
 export const PostContractsRequest = t.intersection([
   t.type({
     contract: Contract,
@@ -122,6 +245,10 @@ export const PostContractsRequest = t.intersection([
   t.partial({ roles: RolesConfig }),
 ]);
 
+// QUESTION: @N.H and @Jamie: This seems to be only used in the context
+//           of creating a contract that later needs to be signed and submitted.
+//           Should we rename this to something like `UnsignedContractTx` or
+//           `UnsignedCreateContractTx`?
 export type ContractTextEnvelope = t.TypeOf<typeof ContractTextEnvelope>;
 export const ContractTextEnvelope = t.type({
   contractId: ContractId,
@@ -133,7 +260,9 @@ export const PostResponse = t.type({
   links: t.type({ contract: t.string }),
   resource: ContractTextEnvelope,
 });
-
+/**
+ * @see {@link https://docs.marlowe.iohk.io/api/create-contracts}
+ */
 export const postViaAxios: (axiosInstance: AxiosInstance) => POST =
   (axiosInstance) => (postContractsRequest, addressesAndCollaterals) =>
     pipe(

--- a/packages/runtime/client/rest/src/contract/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/contract/endpoints/collection.ts
@@ -219,7 +219,6 @@ export type CreateContractRequest = {
    * The validator version to use.
    */
   version: MarloweVersion;
-
 };
 
 export type POST = (

--- a/packages/runtime/client/rest/src/contract/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/contract/endpoints/collection.ts
@@ -48,12 +48,12 @@ export const unContractsRange = iso<ContractsRange>().unwrap;
 export const contractsRange = iso<ContractsRange>().wrap;
 
 /**
- * Request options for the {@link index.RuntimeFlatApi#getContracts | Get contracts } endpoint
+ * Request options for the {@link index.RestAPI#getContracts | Get contracts } endpoint
  * @category Endpoints
  */
 export type GetContractsRequest = {
   /**
-   * Optional pagination request. Note that when you call {@link index.RuntimeFlatApi#getContracts | Get contracts }
+   * Optional pagination request. Note that when you call {@link index.RestAPI#getContracts | Get contracts }
    * the response includes the next and previous range headers.
    */
   // QUESTION: @Jamie, is this supposed to be constructed by the user? or solely from other endpoints?
@@ -133,7 +133,7 @@ export const GETByRangeRawResponse = t.type({
 });
 
 /**
- * Represents the response of the {@link index.RuntimeFlatApi | Get contracts } endpoint
+ * Represents the response of the {@link index.RestAPI#getContracts | Get contracts } endpoint
  * @see The {@link GetContractsResponse:var | dynamic validator} for this type.
  * @category GetContractsResponse
  */
@@ -169,7 +169,7 @@ export const GetContractsResponse = t.type({
 });
 
 /**
- * Request options for the {@link index.RuntimeFlatApi#createContract | Create contract } endpoint
+ * Request options for the {@link index.RestAPI#createContract | Create contract } endpoint
  * @category Endpoints
  */
 export type CreateContractRequest = {

--- a/packages/runtime/client/rest/src/contract/endpoints/singleton.ts
+++ b/packages/runtime/client/rest/src/contract/endpoints/singleton.ts
@@ -12,6 +12,7 @@ import { DecodingError } from "@marlowe.io/adapter/codec";
 
 import {
   HexTransactionWitnessSet,
+  TextEnvelope,
   transactionWitnessSetTextEnvelope,
 } from "@marlowe.io/runtime-core";
 
@@ -25,6 +26,9 @@ export type GET = (
 type GETPayload = t.TypeOf<typeof GETPayload>;
 const GETPayload = t.type({ links: t.type({}), resource: ContractDetails });
 
+/**
+ * @see {@link https://docs.marlowe.iohk.io/api/get-contracts-by-id}
+ */
 export const getViaAxios: (axiosInstance: AxiosInstance) => GET =
   (axiosInstance) => (contractId) =>
     pipe(
@@ -47,6 +51,23 @@ export type PUT = (
   hexTransactionWitnessSet: HexTransactionWitnessSet
 ) => TE.TaskEither<Error, void>;
 
+export const submitContractViaAxios =
+  (axiosInstance: AxiosInstance) =>
+  (contractId: ContractId, envelope: TextEnvelope) =>
+    axiosInstance
+      .put(contractEndpoint(contractId), envelope, {
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+      })
+      .then((_) => {
+        return;
+      });
+/**
+ * @deprecated
+ * @see {@link https://docs.marlowe.iohk.io/api/create-contracts-by-id}
+ */
 export const putViaAxios: (axiosInstance: AxiosInstance) => PUT =
   (axiosInstance) => (contractId, hexTransactionWitnessSet) =>
     pipe(

--- a/packages/runtime/client/rest/src/contract/header.ts
+++ b/packages/runtime/client/rest/src/contract/header.ts
@@ -20,7 +20,7 @@ import { ContractId } from "@marlowe.io/runtime-core";
  * @see The {@link https://github.com/input-output-hk/marlowe-cardano/blob/b39fe3c3ed67d41cdea6d45700093e7ffa4fad62/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs#L502 | The backend definition } of this type
  * @category GetContractsResponse
  */
-export interface ContractHeader extends t.TypeOf<typeof ContractHeader> {};
+export interface ContractHeader extends t.TypeOf<typeof ContractHeader> {}
 /**
  * This is a {@link !io-ts-usage | Dynamic type validator} for a {@link ContractHeader:type}.
  * @category Validator

--- a/packages/runtime/client/rest/src/contract/header.ts
+++ b/packages/runtime/client/rest/src/contract/header.ts
@@ -12,14 +12,27 @@ import {
 
 import { TxStatus } from "./transaction/status.js";
 import { ContractId } from "@marlowe.io/runtime-core";
-
-export type Header = t.TypeOf<typeof Header>;
-export const Header = t.type({
+/**
+ * A contract header contains minimal contract information that can be used to identify a contract.
+ * Use TODO to get full contract details
+ *
+ * @see The {@link ContractHeader:var | dynamic validator} for this type.
+ * @see The {@link https://github.com/input-output-hk/marlowe-cardano/blob/b39fe3c3ed67d41cdea6d45700093e7ffa4fad62/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs#L502 | The backend definition } of this type
+ * @category GetContractsResponse
+ */
+export interface ContractHeader extends t.TypeOf<typeof ContractHeader> {};
+/**
+ * This is a {@link !io-ts-usage | Dynamic type validator} for a {@link ContractHeader:type}.
+ * @category Validator
+ * @category GetContractsResponse
+ */
+export const ContractHeader = t.type({
   contractId: ContractId,
   roleTokenMintingPolicyId: PolicyId,
   version: MarloweVersion,
+  // TODO: Add continuations
+  tags: Tags,
+  metadata: Metadata,
   status: TxStatus,
   block: optionFromNullable(BlockHeader),
-  metadata: Metadata,
-  tags: Tags,
 });

--- a/packages/runtime/client/rest/src/contract/index.ts
+++ b/packages/runtime/client/rest/src/contract/index.ts
@@ -1,3 +1,12 @@
-export * from "./header.js";
-export * from "./details.js";
-export * from "./role.js";
+/**
+ * ```ts
+ * import * as C from "@marlowe.io/runtime-rest-client/contract";
+ *```
+ * @packageDocumentation
+ */
+
+// TODO: See what is really needed to be exported
+export {ContractHeader} from "./header.js";
+// export * from "./details.js";
+export {RolesConfig} from "./role.js";
+export { GetContractsResponse, GetContractsRequest, ContractsRange, CreateContractRequest } from "./endpoints/collection.js";

--- a/packages/runtime/client/rest/src/contract/index.ts
+++ b/packages/runtime/client/rest/src/contract/index.ts
@@ -5,8 +5,12 @@
  * @packageDocumentation
  */
 
-// TODO: See what is really needed to be exported
-export {ContractHeader} from "./header.js";
-// export * from "./details.js";
-export {RolesConfig} from "./role.js";
-export { GetContractsResponse, GetContractsRequest, ContractsRange, CreateContractRequest } from "./endpoints/collection.js";
+export { ContractHeader } from "./header.js";
+export { ContractDetails } from "./details.js";
+export { RolesConfig } from "./role.js";
+export {
+  GetContractsResponse,
+  GetContractsRequest,
+  ContractsRange,
+  CreateContractRequest,
+} from "./endpoints/collection.js";

--- a/packages/runtime/client/rest/src/contract/transaction/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/contract/transaction/endpoints/collection.ts
@@ -25,7 +25,7 @@ import {
   unTxOutRef,
 } from "@marlowe.io/runtime-core";
 
-import { Header } from "../header.js";
+import { TxHeader } from "../header.js";
 import { TransactionId } from "../id.js";
 import { ContractId, unContractId } from "@marlowe.io/runtime-core";
 
@@ -61,7 +61,7 @@ export const getHeadersByRangeViaAxios: (
     })),
     TE.chainW((data) =>
       TE.fromEither(
-        E.mapLeft(formatValidationErrors)(GETByRangeRawResponse.decode(data))
+        E.mapLeft(formatValidationErrors)(GetContractsRawResponse.decode(data))
       )
     ),
     TE.map((rawResponse) => ({
@@ -74,10 +74,10 @@ export const getHeadersByRangeViaAxios: (
     }))
   );
 
-type GETByRangeRawResponse = t.TypeOf<typeof GETByRangeRawResponse>;
-const GETByRangeRawResponse = t.type({
+type GetContractsRawResponse = t.TypeOf<typeof GetContractsRawResponse>;
+const GetContractsRawResponse = t.type({
   data: t.type({
-    results: t.array(t.type({ links: t.type({}), resource: Header })),
+    results: t.array(t.type({ links: t.type({}), resource: TxHeader })),
   }),
   previousRange: optionFromNullable(TransactionsRange),
   nextRange: optionFromNullable(TransactionsRange),
@@ -85,7 +85,7 @@ const GETByRangeRawResponse = t.type({
 
 export type GETByRangeResponse = t.TypeOf<typeof GETByRangeResponse>;
 export const GETByRangeResponse = t.type({
-  headers: t.array(Header),
+  headers: t.array(TxHeader),
   previousRange: optionFromNullable(TransactionsRange),
   nextRange: optionFromNullable(TransactionsRange),
 });

--- a/packages/runtime/client/rest/src/contract/transaction/header.ts
+++ b/packages/runtime/client/rest/src/contract/transaction/header.ts
@@ -20,7 +20,7 @@ import { TxStatus } from "./status.js";
  * @see The {@link TxHeader:var | dynamic validator} for this type.
  * @see The {@link https://github.com/input-output-hk/marlowe-cardano/blob/b39fe3c3ed67d41cdea6d45700093e7ffa4fad62/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs#L502 | The backend definition } of this type
  */
-export interface TxHeader extends t.TypeOf<typeof TxHeader> {};
+export interface TxHeader extends t.TypeOf<typeof TxHeader> {}
 
 /**
  * This is a {@link !io-ts-usage | Dynamic type validator} for a {@link TxHeader:type}.

--- a/packages/runtime/client/rest/src/contract/transaction/header.ts
+++ b/packages/runtime/client/rest/src/contract/transaction/header.ts
@@ -13,8 +13,23 @@ import { ContractId } from "@marlowe.io/runtime-core";
 import { TransactionId } from "./id.js";
 import { TxStatus } from "./status.js";
 
-export type Header = t.TypeOf<typeof Header>;
-export const Header = t.type({
+// TODO: Link to getTransactions endpoint
+/**
+ * A Marlowe Transaction Header contains information about a contract transaction.
+ *
+ * @see The {@link TxHeader:var | dynamic validator} for this type.
+ * @see The {@link https://github.com/input-output-hk/marlowe-cardano/blob/b39fe3c3ed67d41cdea6d45700093e7ffa4fad62/marlowe-runtime-web/src/Language/Marlowe/Runtime/Web/Types.hs#L502 | The backend definition } of this type
+ */
+export interface TxHeader extends t.TypeOf<typeof TxHeader> {};
+
+/**
+ * This is a {@link !io-ts-usage | Dynamic type validator} for a {@link TxHeader:type}.
+ * @category Validator
+ */
+export const TxHeader = t.type({
+  /**
+   * The ID of the Marlowe contract instance
+   */
   contractId: ContractId,
   transactionId: TransactionId,
   continuations: optionFromNullable(BuiltinByteString),

--- a/packages/runtime/client/rest/src/index.ts
+++ b/packages/runtime/client/rest/src/index.ts
@@ -1,6 +1,17 @@
+/**
+ * This is the main entry point of the @marlowe.io/runtime-rest-client package.
+ * You can import it like this:
+ *
+ * ```ts
+ * import { mkRestClient } from "@marlowe.io/runtime-rest-client";
+ * ```
+ * @packageDocumentation
+ */
+
 import axios from "axios";
 import * as TE from "fp-ts/lib/TaskEither.js";
-import { pipe } from "fp-ts/lib/function.js";
+import * as O from "fp-ts/lib/Option.js";
+import { flow, pipe } from "fp-ts/lib/function.js";
 
 import { MarloweJSONCodec } from "@marlowe.io/adapter/codec";
 import * as HTTP from "@marlowe.io/adapter/http";
@@ -15,86 +26,282 @@ import * as Contracts from "./contract/endpoints/collection.js";
 import * as Transaction from "./contract/transaction/endpoints/singleton.js";
 import * as Transactions from "./contract/transaction/endpoints/collection.js";
 import * as ContractNext from "./contract/next/endpoint.js";
+import { unsafeTaskEither } from "@marlowe.io/adapter/fp-ts";
+import { ContractId, TextEnvelope } from "@marlowe.io/runtime-core";
+import { submitContractViaAxios } from "./contract/endpoints/singleton.js";
 // import curlirize from 'axios-curlirize';
 
-export * from "./contract/index.js";
-export * from "./withdrawal/index.js";
-export * from "./payout/index.js";
+// TODO: DELETE
+// export * from "./contract/index.js";
+// export * from "./withdrawal/index.js";
+// export * from "./payout/index.js";
+// TODO: Revisit
+export { Assets, Tokens } from "./payout/index.js";
+export { RolesConfig } from "./contract/index.js";
+// Jamie Straw suggestion: 20 endpoints
+// Runtime Rest API docs: 18 endpoints (missing, getPayouts and getPayoutById, I assume version 0.0.5)
+// Current TS-SDK: 16 endpoints
+//   https://docs.marlowe.iohk.io/api
+// openapi.json on main (RC 0.0.5): 20 endpoints
+/**
+ * This interface is a 1-1 mapping of the {@link https://docs.marlowe.iohk.io/api/ | Marlowe API endpoints}.
+ */
+export interface RuntimeFlatApi {
+    /**
+     * Gets a paginated list of contracts {@link contract.ContractHeader }
+     * @param request Optional filtering and pagination options.
+     * @throws DecodingError If the response from the server can't be decoded
+     * @see {@link https://docs.marlowe.iohk.io/api/get-contracts}
+     */
+    getContracts(request?: Contracts.GetContractsRequest): Promise<Contracts.GetContractsResponse>;
 
-export type RestDI = { rest: RestAPI };
+    /**
+     * Builds an unsigned transaction to create an instance of a Marlowe Contract.
+     *
+     * @param request Request parameters including the Contract to create, role information, metadata, etc.
+     * @returns An object with the CBOR encoded transaction to sign (using the `wallet` package) and submit to the blockchain (using the TODO method).
+     * @throws DecodingError - If the response from the server can't be decoded
+     * @see {@link https://docs.marlowe.iohk.io/api/create-contracts | The backend documentation}
+     */
+     // TODO: fix link cross package
+    // TODO: Jamie, remove the `s from the end of the endpoint name in the docs site
+    // DISCUSSION: @Jamie, @N.H: Should this be called `buildCreateContractTx` instead? As it is not creating the
+    //             contract, rather it is creating the transaction to be signed
+    createContract(request: Contracts.CreateContractRequest): Promise<Contracts.ContractTextEnvelope>;
 
-export interface RestAPI {
-  healthcheck: () => TE.TaskEither<Error, Boolean>;
-  payouts: {
-    getHeadersByRange: Payouts.GETHeadersByRange;
-    get: Payout.GET;
+  //   getContractById: Contract.GET; // - https://docs.marlowe.iohk.io/api/get-contracts-by-id // TODO: Jamie, remove the `s from the end of the endpoint name
+  //   In the docs site, after getContractsById there is https://docs.marlowe.iohk.io/api/create-contracts-by-id, not sure what method it corresponds or what is that method supposed to do.
+    /**
+     * Submits a signed contract creation transaction
+     */
+    submitContract(contractId: ContractId, txEnvelope: TextEnvelope): Promise<void>;
+  //
+  //   getTransactionsForContract: Transactions.GET; // - https://docs.marlowe.iohk.io/api/get-transactions // TODO: Jamie, lets unify names
+  //   createTransactionForContract: Transactions.POST; // - https://docs.marlowe.iohk.io/api/create-transactions // TODO: Jamie, lets unify names
+  //   getTransactionById: Transaction.GET; // - https://docs.marlowe.iohk.io/api/get-transaction-by-id
+  //   submitTransaction: Transaction.PUT; // - Jamie is it this one? https://docs.marlowe.iohk.io/api/create-transaction-by-id? If so, lets unify
+
+  //   getWithdrawals: Withdrawals.GET; // - https://docs.marlowe.iohk.io/api/get-withdrawals
+  //   createWithdrawal: Withdrawals.POST; // - https://docs.marlowe.iohk.io/api/create-withdrawals
+  //   getWithdrawalById: Withdrawal.GET; // - https://docs.marlowe.iohk.io/api/get-withdrawal-by-id
+  //   submitWithdrawal: Withdrawal.PUT; - is it this one? https://docs.marlowe.iohk.io/api/create-withdrawal? or the one for createWithdrawal?
+  // TODO: Create ticket to also export return headers information
+  // Node-Tip Runtime-Chain-Tip Runtime-Tip Runtime-Version Network-Id
+  /**
+   * Checks if the Marlowe API is up and running.
+   *
+   * @see {@link https://docs.marlowe.iohk.io/api/health-check-endpoint}
+   */
+  healthcheck(): Promise<Boolean>;
+
+  //   getNextStepsForContract: Next.GET; // - Jamie, is it this one? https://docs.marlowe.iohk.io/api/get-transaction-output-by-id? if so lets unify
+
+  //   postContractSource: ContractSources.POST; // - Jamie, is it this one? https://docs.marlowe.iohk.io/api/access-contract-import if so lets unify
+  //   getContractSource: ContractSource.GET; // - Jamie, is it this one? https://docs.marlowe.iohk.io/api/get-contract-import-by-id
+  //   getContractAdjacency: ContractSource.GET_ADJACENCY;  // - Jamie, is it this one? https://docs.marlowe.iohk.io/api/get-adjacency-by-id if so lets unify
+  //   getContractClosure: ContractSource.GET_CLOSURE; // Jamie is it this one? - https://docs.marlowe.iohk.io/api/get-closure-by-id
+
+  //   getPayouts: Payouts.GET;
+  //   getPayoutById: Payout.GET;
+}
+
+
+/**
+ * Instantiates a REST client for the Marlowe API.
+ * @param baseURL An http url pointing to the Marlowe API.
+ * @see {@link https://github.com/input-output-hk/marlowe-starter-kit#quick-overview} To get a Marlowe runtime instance up and running.
+ */
+export function mkFlatRestClient(baseURL: string): RuntimeFlatApi {
+  const axiosInstance = axios.create({
+    baseURL: baseURL,
+    transformRequest: MarloweJSONCodec.encode,
+    transformResponse: MarloweJSONCodec.decode,
+  });
+
+  return {
+    getContracts(request) {
+      const rangeOption = O.fromNullable(request?.range);
+      const tags = request?.tags ?? [];
+      return unsafeTaskEither(
+        Contracts.getHeadersByRangeViaAxios(axiosInstance)(rangeOption)(tags)
+      );
+    },
+    createContract(request) {
+      const postContractsRequest = {
+        contract: request.contract,
+        version: request.version,
+        metadata: request.metadata,
+        tags: request.tags,
+        minUTxODeposit: request.minUTxODeposit,
+        roles: request.roles,
+      };
+      const addressesAndCollaterals = {
+        changeAddress: request.changeAddress,
+        usedAddresses: request.usedAddresses ?? [],
+        collateralUTxOs: request.collateralUTxOs ?? [],
+      };
+      return unsafeTaskEither(
+        Contracts.postViaAxios(axiosInstance)(postContractsRequest, addressesAndCollaterals)
+      )
+    },
+
+    submitContract(contractId, txEnvelope) {
+      return submitContractViaAxios(axiosInstance)(contractId, txEnvelope);
+    },
+    healthcheck: () =>
+      pipe(HTTP.Get(axiosInstance)("/healthcheck"), TE.match(()=> false, () => true))(),
+  }
+}
+
+
+// TODO: Move to Payouts?
+/**
+ * @hidden
+ */
+export interface PayoutsAPI {
+  getHeadersByRange: Payouts.GETHeadersByRange;
+  get: Payout.GET;
+}
+
+// TODO: Move to Withdrawals?
+/**
+ * @hidden
+ */
+export interface WithdrawalsAPI {
+  /**
+   * @see {@link https://docs.marlowe.iohk.io/api/get-withdrawals}
+   */
+  getHeadersByRange: Withdrawals.GETHeadersByRange;
+  /**
+   * @see {@link https://docs.marlowe.iohk.io/api/create-withdrawals}
+   */
+  post: Withdrawals.POST;
+  withdrawal: {
+    /**
+     * @see {@link https://docs.marlowe.iohk.io/api/get-withdrawal-by-id}
+     */
+    get: Withdrawal.GET;
+    /**
+     * @see {@link https://docs.marlowe.iohk.io/api/create-withdrawal}
+     */
+    put: Withdrawal.PUT;
   };
-  withdrawals: {
-    getHeadersByRange: Withdrawals.GETHeadersByRange;
-    post: Withdrawals.POST;
-    withdrawal: {
-      get: Withdrawal.GET;
-      put: Withdrawal.PUT;
-    };
-  };
-  contracts: {
-    getHeadersByRange: Contracts.GETHeadersByRange;
-    post: Contracts.POST;
-    contract: {
-      get: Contract.GET;
-      put: Contract.PUT;
-      next: ContractNext.GET;
-      transactions: {
-        getHeadersByRange: Transactions.GETHeadersByRange;
-        post: Transactions.POST;
-        transaction: {
-          get: Transaction.GET;
-          put: Transaction.PUT;
-        };
+}
+
+// TODO: Move to Contracts?
+/**
+ * @hidden
+ */
+export interface ContractsAPI {
+  /**
+   * @see {@link https://docs.marlowe.iohk.io/api/get-contracts}
+   */
+  getHeadersByRange: Contracts.GETHeadersByRange;
+  /**
+   * @see {@link https://docs.marlowe.iohk.io/api/create-contracts}
+   */
+  post: Contracts.POST;
+  contract: {
+    /**
+     * Get a single contract by id
+     * @see {@link https://docs.marlowe.iohk.io/api/get-contracts-by-id}
+     */
+    get: Contract.GET;
+    /**
+     * @see {@link https://docs.marlowe.iohk.io/api/create-contracts-by-id}
+     */
+    put: Contract.PUT;
+    /**
+     * @see {@link }
+     */
+    next: ContractNext.GET;
+    transactions: {
+      /**
+       * @see {@link }
+       */
+      getHeadersByRange: Transactions.GETHeadersByRange;
+      /**
+       * @see {@link }
+       */
+      post: Transactions.POST;
+      transaction: {
+        /**
+         * @see {@link }
+         */
+        get: Transaction.GET;
+        /**
+         * @see {@link }
+         */
+        put: Transaction.PUT;
       };
     };
   };
 }
 
-export const mkRestClient: (baseURL: string) => RestAPI = (baseURL) =>
-  pipe(
-    axios.create({
-      baseURL: baseURL,
-      transformRequest: MarloweJSONCodec.encode,
-      transformResponse: MarloweJSONCodec.decode,
-    }),
-    //  , (axiosInstance) => {curlirize(axiosInstance) ;return axiosInstance }
-    (axiosInstance) => ({
-      healthcheck: () => HTTP.Get(axiosInstance)("/healthcheck"),
-      payouts: {
-        getHeadersByRange: Payouts.getHeadersByRangeViaAxios(axiosInstance),
-        get: Payout.getViaAxios(axiosInstance),
+/**
+ * @hidden
+ */
+export type RestDI = { rest: RestAPI };
+
+/**
+ * @hidden
+ */
+export interface RestAPI {
+  // NOTE: In FP-TS this should probably be T.Task<boolean>, the current implementation returns true or Error.
+  /**
+   * @see {@link }
+   */
+  healthcheck: () => TE.TaskEither<Error, Boolean>;
+  payouts: PayoutsAPI;
+  withdrawals: WithdrawalsAPI;
+  contracts: ContractsAPI;
+}
+
+/**
+ * Instantiates a REST client for the Marlowe API.
+ * @hidden
+ * @param baseURL An http url pointing to the Marlowe API.
+ * @see {@link https://github.com/input-output-hk/marlowe-starter-kit#quick-overview} To get a Marlowe runtime instance up and running.
+ */
+export function mkRestClient(baseURL: string): RestAPI {
+  const axiosInstance = axios.create({
+    baseURL: baseURL,
+    transformRequest: MarloweJSONCodec.encode,
+    transformResponse: MarloweJSONCodec.decode,
+  });
+
+  return {
+
+    healthcheck: () => pipe(HTTP.Get(axiosInstance)("/healthcheck"), TE.map(() => true)),
+    payouts: {
+      getHeadersByRange: Payouts.getHeadersByRangeViaAxios(axiosInstance),
+      get: Payout.getViaAxios(axiosInstance),
+    },
+    withdrawals: {
+      getHeadersByRange: Withdrawals.getHeadersByRangeViaAxios(axiosInstance),
+      post: Withdrawals.postViaAxios(axiosInstance),
+      withdrawal: {
+        get: Withdrawal.getViaAxios(axiosInstance),
+        put: Withdrawal.putViaAxios(axiosInstance),
       },
-      withdrawals: {
-        getHeadersByRange: Withdrawals.getHeadersByRangeViaAxios(axiosInstance),
-        post: Withdrawals.postViaAxios(axiosInstance),
-        withdrawal: {
-          get: Withdrawal.getViaAxios(axiosInstance),
-          put: Withdrawal.putViaAxios(axiosInstance),
-        },
-      },
-      contracts: {
-        getHeadersByRange: Contracts.getHeadersByRangeViaAxios(axiosInstance),
-        post: Contracts.postViaAxios(axiosInstance),
-        contract: {
-          get: Contract.getViaAxios(axiosInstance),
-          put: Contract.putViaAxios(axiosInstance),
-          next: ContractNext.getViaAxios(axiosInstance),
-          transactions: {
-            getHeadersByRange:
-              Transactions.getHeadersByRangeViaAxios(axiosInstance),
-            post: Transactions.postViaAxios(axiosInstance),
-            transaction: {
-              get: Transaction.getViaAxios(axiosInstance),
-              put: Transaction.putViaAxios(axiosInstance),
-            },
+    },
+    contracts: {
+      getHeadersByRange: Contracts.getHeadersByRangeViaAxios(axiosInstance),
+      post: Contracts.postViaAxios(axiosInstance),
+      contract: {
+        get: Contract.getViaAxios(axiosInstance),
+        put: Contract.putViaAxios(axiosInstance),
+        next: ContractNext.getViaAxios(axiosInstance),
+        transactions: {
+          getHeadersByRange:
+            Transactions.getHeadersByRangeViaAxios(axiosInstance),
+          post: Transactions.postViaAxios(axiosInstance),
+          transaction: {
+            get: Transaction.getViaAxios(axiosInstance),
+            put: Transaction.putViaAxios(axiosInstance),
           },
         },
       },
-    })
-  );
+    },
+  };
+}

--- a/packages/runtime/client/rest/src/index.ts
+++ b/packages/runtime/client/rest/src/index.ts
@@ -46,7 +46,7 @@ export { RolesConfig } from "./contract/index.js";
 /**
  * This interface is a 1-1 mapping of the {@link https://docs.marlowe.iohk.io/api/ | Marlowe API endpoints}.
  */
-export interface RuntimeFlatApi {
+export interface RestAPI {
     /**
      * Gets a paginated list of contracts {@link contract.ContractHeader }
      * @param request Optional filtering and pagination options.
@@ -111,7 +111,7 @@ export interface RuntimeFlatApi {
  * @param baseURL An http url pointing to the Marlowe API.
  * @see {@link https://github.com/input-output-hk/marlowe-starter-kit#quick-overview} To get a Marlowe runtime instance up and running.
  */
-export function mkFlatRestClient(baseURL: string): RuntimeFlatApi {
+export function mkRestClient(baseURL: string): RestAPI {
   const axiosInstance = axios.create({
     baseURL: baseURL,
     transformRequest: MarloweJSONCodec.encode,
@@ -241,12 +241,12 @@ export interface ContractsAPI {
 /**
  * @hidden
  */
-export type RestDI = { rest: RestAPI };
+export type RestDI = { rest: FPTSRestAPI };
 
 /**
  * @hidden
  */
-export interface RestAPI {
+export interface FPTSRestAPI {
   // NOTE: In FP-TS this should probably be T.Task<boolean>, the current implementation returns true or Error.
   /**
    * @see {@link }
@@ -258,12 +258,10 @@ export interface RestAPI {
 }
 
 /**
- * Instantiates a REST client for the Marlowe API.
+ * Legacy FP-TS version
  * @hidden
- * @param baseURL An http url pointing to the Marlowe API.
- * @see {@link https://github.com/input-output-hk/marlowe-starter-kit#quick-overview} To get a Marlowe runtime instance up and running.
  */
-export function mkRestClient(baseURL: string): RestAPI {
+export function mkFPTSRestClient(baseURL: string): FPTSRestAPI {
   const axiosInstance = axios.create({
     baseURL: baseURL,
     transformRequest: MarloweJSONCodec.encode,

--- a/packages/runtime/client/rest/src/withdrawal/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/withdrawal/endpoints/collection.ts
@@ -36,6 +36,9 @@ export type GETHeadersByRange = (
   rangeOption: O.Option<WithdrawalsRange>
 ) => TE.TaskEither<Error | DecodingError, GETByRangeResponse>;
 
+/**
+ * @see {@link https://docs.marlowe.iohk.io/api/get-withdrawals}
+ */
 export const getHeadersByRangeViaAxios: (
   axiosInstance: AxiosInstance
 ) => GETHeadersByRange = (axiosInstance) => (rangeOption) =>
@@ -108,6 +111,9 @@ export const PostResponse = t.type({
   resource: WithdrawalTextEnvelope,
 });
 
+/**
+ * @see {@link https://docs.marlowe.iohk.io/api/create-withdrawals}
+ */
 export const postViaAxios: (axiosInstance: AxiosInstance) => POST =
   (axiosInstance) => (payoutIds, addressesAndCollaterals) =>
     pipe(

--- a/packages/runtime/client/rest/src/withdrawal/endpoints/singleton.ts
+++ b/packages/runtime/client/rest/src/withdrawal/endpoints/singleton.ts
@@ -21,6 +21,9 @@ export type GET = (
   withdrawalId: WithdrawalId
 ) => TE.TaskEither<Error | DecodingError, WithdrawalDetails>;
 
+/**
+ * @see {@link https://docs.marlowe.iohk.io/api/get-withdrawal-by-id}
+ */
 export const getViaAxios: (axiosInstance: AxiosInstance) => GET =
   (axiosInstance) => (withdrawalId) =>
     pipe(
@@ -42,6 +45,9 @@ export type PUT = (
   hexTransactionWitnessSet: HexTransactionWitnessSet
 ) => TE.TaskEither<Error, void>;
 
+/**
+ * @see {@link https://docs.marlowe.iohk.io/api/create-withdrawal}
+ */
 export const putViaAxios: (axiosInstance: AxiosInstance) => PUT =
   (axiosInstance) => (withdrawalId, hexTransactionWitnessSet) =>
     pipe(

--- a/packages/runtime/client/rest/test/endpoints/contracts.spec.e2e.ts
+++ b/packages/runtime/client/rest/test/endpoints/contracts.spec.e2e.ts
@@ -2,7 +2,7 @@ import { pipe } from "fp-ts/lib/function.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
 import * as O from "fp-ts/lib/Option.js";
 
-import { mkRestClient } from "@marlowe.io/runtime-rest-client/index.js";
+import { mkFPTSRestClient } from "@marlowe.io/runtime-rest-client/index.js";
 
 import { getMarloweRuntimeUrl } from "../context.js";
 
@@ -10,7 +10,7 @@ import console from "console";
 global.console = console;
 
 describe("contracts endpoints", () => {
-  const restClient = mkRestClient(getMarloweRuntimeUrl());
+  const restClient = mkFPTSRestClient(getMarloweRuntimeUrl());
 
   it(
     "can navigate throught Initialised Marlowe Contracts pages" +

--- a/packages/runtime/client/rest/test/endpoints/payouts.spec.e2e.ts
+++ b/packages/runtime/client/rest/test/endpoints/payouts.spec.e2e.ts
@@ -2,7 +2,7 @@ import { pipe } from "fp-ts/lib/function.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
 import * as O from "fp-ts/lib/Option.js";
 
-import { mkRestClient } from "@marlowe.io/runtime-rest-client/index.js";
+import { mkFPTSRestClient } from "@marlowe.io/runtime-rest-client/index.js";
 
 import { getMarloweRuntimeUrl } from "../context.js";
 
@@ -10,7 +10,7 @@ import console from "console";
 global.console = console;
 
 describe("payouts endpoints", () => {
-  const restClient = mkRestClient(getMarloweRuntimeUrl());
+  const restClient = mkFPTSRestClient(getMarloweRuntimeUrl());
 
   it("can navigate throught payout headers" + "(GET:  /payouts)", async () => {
     await pipe(

--- a/packages/runtime/client/rest/test/endpoints/transactions.spec.e2e.ts
+++ b/packages/runtime/client/rest/test/endpoints/transactions.spec.e2e.ts
@@ -1,11 +1,11 @@
-import { mkRestClient } from "@marlowe.io/runtime-rest-client/index.js";
+import { mkFPTSRestClient } from "@marlowe.io/runtime-rest-client/index.js";
 import console from "console";
 import { getMarloweRuntimeUrl } from "../context.js";
 
 global.console = console;
 
 describe.skip("ransactions endpoints", () => {
-  const restClient = mkRestClient(getMarloweRuntimeUrl());
+  const restClient = mkFPTSRestClient(getMarloweRuntimeUrl());
 
   it(
     "can navigate throught transaction headers" +

--- a/packages/runtime/client/rest/typedoc.json
+++ b/packages/runtime/client/rest/typedoc.json
@@ -1,5 +1,7 @@
 {
   "entryPointStrategy": "expand",
-  "entryPoints": ["./src"],
-  "tsconfig": "./src/tsconfig.json"
+  "entryPoints": ["./src/index.ts", "./src/contract/index.ts", "./src/payout/index.ts", "./src/withdrawal/index.ts"],
+  "tsconfig": "./src/tsconfig.json",
+  "categorizeByGroup": false,
+  "defaultCategory": "General"
 }

--- a/packages/runtime/client/rest/typedoc.json
+++ b/packages/runtime/client/rest/typedoc.json
@@ -1,6 +1,11 @@
 {
   "entryPointStrategy": "expand",
-  "entryPoints": ["./src/index.ts", "./src/contract/index.ts", "./src/payout/index.ts", "./src/withdrawal/index.ts"],
+  "entryPoints": [
+    "./src/index.ts",
+    "./src/contract/index.ts",
+    "./src/payout/index.ts",
+    "./src/withdrawal/index.ts"
+  ],
   "tsconfig": "./src/tsconfig.json",
   "categorizeByGroup": false,
   "defaultCategory": "General"

--- a/packages/runtime/core/package.json
+++ b/packages/runtime/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marlowe.io/runtime-core",
-  "version": "0.2.0-alpha-1",
+  "version": "0.2.0-alpha-2",
   "description": "Core concepts used throughout the Marlowe Runtime libraries",
   "repository": "https://github.com/input-output-hk/marlowe-ts-sdk",
   "publishConfig": {

--- a/packages/runtime/core/src/asset/index.ts
+++ b/packages/runtime/core/src/asset/index.ts
@@ -22,7 +22,7 @@ export const assetId: (
 // NOTE: this is exported as interface to prevent typedoc from expanding its attributes when
 //       generating documentation.
 //       https://github.com/TypeStrong/typedoc/issues/2209#issuecomment-1493189988
-export interface Token extends t.TypeOf<typeof Token> {};
+export interface Token extends t.TypeOf<typeof Token> {}
 export const Token = t.type({ quantity: AssetQuantity, assetId: AssetId });
 
 export const token: (quantity: AssetQuantity) => (assetId: AssetId) => Token =

--- a/packages/runtime/core/src/payout/index.ts
+++ b/packages/runtime/core/src/payout/index.ts
@@ -8,6 +8,7 @@ import { TxId } from "../tx/id.js";
 import { ContractId } from "../contract/id.js";
 import { AssetId, Assets } from "../asset/index.js";
 
+// QUESTION: @N.H: What is the difference between PayoutId and WithdrawalId?
 export type PayoutId = Newtype<{ readonly ContractId: unique symbol }, string>;
 export const PayoutId = fromNewtype<PayoutId>(t.string);
 export const unPayoutId = iso<PayoutId>().unwrap;

--- a/packages/runtime/core/src/textEnvelope.ts
+++ b/packages/runtime/core/src/textEnvelope.ts
@@ -3,8 +3,16 @@ import { Newtype } from "newtype-ts";
 import { fromNewtype, option, optionFromNullable } from "io-ts-types";
 import * as t from "io-ts/lib/index.js";
 
-// see : https://input-output-hk.github.io/cardano-node/cardano-api/lib/Cardano-Api-SerialiseTextEnvelope.html
-
+/**
+ * @see {@link https://input-output-hk.github.io/cardano-node/cardano-api/lib/Cardano-Api-SerialiseTextEnvelope.html}
+ */
+// DISCUSSION: The same structure serves for unsigned and signed transactions... Should we make them nominal
+//             so that you cannot confuse them? Maybe a simple Singed or Unsigned is a good starting point but
+//             might be insufficient for multiple signatures. To capture that we could have two type parameters
+//             "missing signatures" and "current signatures" and by signing something we move it from missing to witness
+//             at the type level.
+//             We could also parametrize the type on the `type` property. I noticed that when we build the transaction
+//             the runtime responds with `Tx BabbageEra` but when we submit it we need to use `ShelleyTxWitness BabbageEra`
 export type TextEnvelope = t.TypeOf<typeof TextEnvelope>;
 export const TextEnvelope = t.type({
   type: t.string,

--- a/packages/runtime/core/src/tx/outRef.ts
+++ b/packages/runtime/core/src/tx/outRef.ts
@@ -1,7 +1,9 @@
 import * as t from "io-ts/lib/index.js";
 import { iso, Newtype } from "newtype-ts";
 import { fromNewtype } from "io-ts-types";
-
+/**
+ * A reference to a transaction output.
+ */
 export type TxOutRef = Newtype<{ readonly TxOutRef: unique symbol }, string>;
 export const TxOutRef = fromNewtype<TxOutRef>(t.string);
 export const unTxOutRef = iso<TxOutRef>().unwrap;

--- a/packages/runtime/lifecycle/package.json
+++ b/packages/runtime/lifecycle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marlowe.io/runtime-lifecycle",
-  "version": "0.2.0-alpha-1",
+  "version": "0.2.0-alpha-2",
   "description": "Entry Point for Running remotely Marlowe Contracts over a backend instance of the runtime using a connected wallet.",
   "repository": "https://github.com/input-output-hk/marlowe-ts-sdk",
   "publishConfig": {
@@ -49,7 +49,7 @@
     }
   },
   "dependencies": {
-    "@marlowe.io/runtime-rest-client": "0.2.0-alpha-1",
+    "@marlowe.io/runtime-rest-client": "0.2.0-alpha-2",
     "fp-ts": "^2.13.1",
     "io-ts": "2.2.20",
     "newtype-ts": "0.3.5",

--- a/packages/runtime/lifecycle/src/browser/index.ts
+++ b/packages/runtime/lifecycle/src/browser/index.ts
@@ -1,7 +1,7 @@
 import { SupportedWallet, mkBrowserWallet } from "@marlowe.io/wallet/browser";
 import * as Generic from "../generic/runtime.js";
 
-import { mkRestClient } from "@marlowe.io/runtime-rest-client";
+import { mkFPTSRestClient } from "@marlowe.io/runtime-rest-client";
 
 /**
  * Options for creating a RuntimeLifecycle instance using the browser wallet.
@@ -28,6 +28,6 @@ export async function mkRuntimeLifecycle({
   walletName,
 }: BrowserRuntimeLifecycleOptions) {
   const wallet = await mkBrowserWallet(walletName);
-  const restClient = mkRestClient(runtimeURL);
+  const restClient = mkFPTSRestClient(runtimeURL);
   return Generic.mkRuntimeLifecycle(restClient, wallet);
 }

--- a/packages/runtime/lifecycle/src/generic/contracts.ts
+++ b/packages/runtime/lifecycle/src/generic/contracts.ts
@@ -21,13 +21,13 @@ import {
   contractIdToTxId,
 } from "@marlowe.io/runtime-core";
 
-import { RestAPI } from "@marlowe.io/runtime-rest-client";
+import { FPTSRestAPI } from "@marlowe.io/runtime-rest-client";
 import { DecodingError } from "@marlowe.io/adapter/codec";
 import * as Tx from "@marlowe.io/runtime-rest-client/transaction";
 
 export function mkContractLifecycle(
   wallet: WalletAPI,
-  rest: RestAPI
+  rest: FPTSRestAPI
 ): ContractsAPI {
   const di = { wallet, rest };
   return {
@@ -74,7 +74,7 @@ const getParties: (
     T.of([]);
 
 export const createContractFpTs: (
-  client: RestAPI
+  client: FPTSRestAPI
 ) => (
   wallet: WalletAPI
 ) => (
@@ -120,7 +120,7 @@ export const createContractFpTs: (
     );
 
 export const applyInputsFpTs: (
-  client: RestAPI
+  client: FPTSRestAPI
 ) => (
   wallet: WalletAPI
 ) => (

--- a/packages/runtime/lifecycle/src/generic/payouts.ts
+++ b/packages/runtime/lifecycle/src/generic/payouts.ts
@@ -17,7 +17,7 @@ import {
   withdrawalIdToTxId,
 } from "@marlowe.io/runtime-core";
 
-import { RestAPI } from "@marlowe.io/runtime-rest-client";
+import { FPTSRestAPI } from "@marlowe.io/runtime-rest-client";
 
 import * as Rest from "@marlowe.io/runtime-rest-client";
 
@@ -26,7 +26,7 @@ import { stringify } from "json-bigint";
 
 export function mkPayoutLifecycle(
   wallet: WalletAPI,
-  rest: RestAPI
+  rest: FPTSRestAPI
 ): PayoutsAPI {
   const di = { wallet, rest };
   return {
@@ -57,7 +57,7 @@ const fetchWithdrawnPayouts =
   };
 
 const fetchAvailablePayoutsFpTs: (
-  restAPI: RestAPI
+  restAPI: FPTSRestAPI
 ) => (
   walletApi: WalletAPI
 ) => (
@@ -104,7 +104,7 @@ const fetchAvailablePayoutsFpTs: (
     );
 
 const fetchWithdrawnPayoutsFpTs: (
-  restAPI: RestAPI
+  restAPI: FPTSRestAPI
 ) => (
   walletApi: WalletAPI
 ) => (
@@ -186,7 +186,7 @@ const getAssetIds: (walletApi: WalletAPI) => TE.TaskEither<Error, AssetId[]> = (
   );
 
 export const withdrawPayoutsFpTs: (
-  client: RestAPI
+  client: FPTSRestAPI
 ) => (
   wallet: WalletAPI
 ) => (payoutIds: PayoutId[]) => TE.TaskEither<Error | DecodingError, void> =

--- a/packages/runtime/lifecycle/src/generic/runtime.ts
+++ b/packages/runtime/lifecycle/src/generic/runtime.ts
@@ -1,13 +1,13 @@
 import { RuntimeLifecycle } from "../api.js";
 import { WalletAPI } from "@marlowe.io/wallet/api";
 
-import { RestAPI } from "@marlowe.io/runtime-rest-client";
+import { FPTSRestAPI } from "@marlowe.io/runtime-rest-client";
 
 import { mkPayoutLifecycle } from "./payouts.js";
 import { mkContractLifecycle } from "./contracts.js";
 
 export function mkRuntimeLifecycle(
-  restAPI: RestAPI,
+  restAPI: FPTSRestAPI,
   wallet: WalletAPI
 ): RuntimeLifecycle {
   return {

--- a/packages/runtime/lifecycle/src/nodejs/index.ts
+++ b/packages/runtime/lifecycle/src/nodejs/index.ts
@@ -1,4 +1,4 @@
-import { mkRestClient } from "@marlowe.io/runtime-rest-client";
+import { mkFPTSRestClient } from "@marlowe.io/runtime-rest-client";
 import * as S from "@marlowe.io/wallet/nodejs";
 import * as Generic from "../generic/runtime.js";
 
@@ -16,6 +16,6 @@ export async function mkRuntimeLifecycle({
     privateKeyBech32
   );
 
-  const restClient = mkRestClient(runtimeURL);
+  const restClient = mkFPTSRestClient(runtimeURL);
   return Generic.mkRuntimeLifecycle(restClient, wallet);
 }

--- a/packages/runtime/lifecycle/test/examples/swap.ada.token.e2e.spec.ts
+++ b/packages/runtime/lifecycle/test/examples/swap.ada.token.e2e.spec.ts
@@ -4,7 +4,7 @@ import { addDays } from "date-fns";
 import { Next, toInput } from "@marlowe.io/language-core-v1/next";
 import * as Examples from "@marlowe.io/language-core-v1/examples";
 import { datetoTimeout, adaValue } from "@marlowe.io/language-core-v1";
-import { mkRestClient } from "@marlowe.io/runtime-rest-client/index.js";
+import { mkFPTSRestClient } from "@marlowe.io/runtime-rest-client/index.js";
 import {
   getBankPrivateKey,
   getBlockfrostContext,
@@ -30,7 +30,7 @@ describe("swap", () => {
           tokenName: "TokenA",
         },
       };
-      const restClient = mkRestClient(getMarloweRuntimeUrl());
+      const restClient = mkFPTSRestClient(getMarloweRuntimeUrl());
       const { tokenValueMinted, adaProvider, tokenProvider, runtime } =
         await provisionAnAdaAndTokenProvider(
           restClient,

--- a/packages/runtime/lifecycle/test/generic/contracts.e2e.spec.ts
+++ b/packages/runtime/lifecycle/test/generic/contracts.e2e.spec.ts
@@ -8,7 +8,7 @@ import {
   close,
 } from "@marlowe.io/language-core-v1";
 import { oneNotifyTrue } from "@marlowe.io/language-core-v1/examples";
-import { mkRestClient } from "@marlowe.io/runtime-rest-client/index.js";
+import { mkFPTSRestClient } from "@marlowe.io/runtime-rest-client/index.js";
 
 import {
   getBankPrivateKey,
@@ -27,7 +27,7 @@ describe("Runtime Contract Lifecycle ", () => {
   it(
     "can create a Marlowe Contract ",
     async () => {
-      const restClient = mkRestClient(getMarloweRuntimeUrl());
+      const restClient = mkFPTSRestClient(getMarloweRuntimeUrl());
       const { runtime } = await initialiseBankAndverifyProvisionning(
         restClient,
         getBlockfrostContext(),
@@ -42,7 +42,7 @@ describe("Runtime Contract Lifecycle ", () => {
     it(
       "can Apply Inputs to a Contract",
       async () => {
-        const restClient = mkRestClient(getMarloweRuntimeUrl());
+        const restClient = mkFPTSRestClient(getMarloweRuntimeUrl());
         const { runtime } = await initialiseBankAndverifyProvisionning(
           restClient,
           getBlockfrostContext(),

--- a/packages/runtime/lifecycle/test/generic/payouts.e2e.spec.ts
+++ b/packages/runtime/lifecycle/test/generic/payouts.e2e.spec.ts
@@ -4,7 +4,7 @@ import { addDays } from "date-fns";
 import * as Examples from "@marlowe.io/language-core-v1/examples";
 import { datetoTimeout, adaValue } from "@marlowe.io/language-core-v1";
 import { Next, toInput } from "@marlowe.io/language-core-v1/next";
-import { mkRestClient } from "@marlowe.io/runtime-rest-client/index.js";
+import { mkFPTSRestClient } from "@marlowe.io/runtime-rest-client/index.js";
 
 import {
   getBankPrivateKey,
@@ -20,7 +20,7 @@ import { MINUTES } from "@marlowe.io/adapter/time";
 global.console = console;
 
 describe("Payouts", () => {
-  const restAPI = mkRestClient(getMarloweRuntimeUrl());
+  const restAPI = mkFPTSRestClient(getMarloweRuntimeUrl());
   const provisionScheme = {
     provider: { adaAmount: 20_000_000n },
     swapper: { adaAmount: 20_000_000n, tokenAmount: 50n, tokenName: "TokenA" },

--- a/packages/runtime/lifecycle/test/provisionning.ts
+++ b/packages/runtime/lifecycle/test/provisionning.ts
@@ -1,6 +1,6 @@
 import { TokenName } from "@marlowe.io/language-core-v1";
 import { mkRuntimeLifecycle } from "@marlowe.io/runtime-lifecycle/generic";
-import { RestAPI } from "@marlowe.io/runtime-rest-client/index.js";
+import { FPTSRestAPI } from "@marlowe.io/runtime-rest-client/index.js";
 import {
   Context,
   SingleAddressWallet,
@@ -19,7 +19,7 @@ export type ProvisionScheme = {
 };
 
 export async function provisionAnAdaAndTokenProvider(
-  restAPI: RestAPI,
+  restAPI: FPTSRestAPI,
   walletContext: Context,
   bankPrivateKey: PrivateKeysAsHex,
   scheme: ProvisionScheme
@@ -77,7 +77,7 @@ export async function provisionAnAdaAndTokenProvider(
 }
 
 export async function initialiseBankAndverifyProvisionning(
-  restAPI: RestAPI,
+  restAPI: FPTSRestAPI,
   walletContext: Context,
   bankPrivateKey: PrivateKeysAsHex
 ) {

--- a/packages/token-metadata-client/package.json
+++ b/packages/token-metadata-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marlowe.io/token-metadata-client",
-  "version": "0.2.0-alpha-1",
+  "version": "0.2.0-alpha-2",
   "description": "TODO",
   "repository": "https://github.com/input-output-hk/marlowe-ts-sdk",
   "publishConfig": {

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marlowe.io/wallet",
-  "version": "0.2.0-alpha-1",
+  "version": "0.2.0-alpha-2",
   "description": "Cardano Wallet Capabalities for Marlowe specific environment",
   "repository": "https://github.com/input-output-hk/marlowe-ts-sdk",
   "publishConfig": {

--- a/pocs/js/poc-helpers.js
+++ b/pocs/js/poc-helpers.js
@@ -1,0 +1,27 @@
+export function clearConsole() {
+  const consoleDiv = document.getElementById("console");
+  consoleDiv.innerHTML = "";
+}
+
+export function log(message) {
+  const consoleDiv = document.getElementById("console");
+  var currentContent = consoleDiv.innerHTML;
+  consoleDiv.innerHTML = currentContent + "<BR>" + message;
+  console.log(message);
+}
+
+export function getRuntimeUrl() {
+  const runtimeUrlInput = document.getElementById("runtimeUrl");
+  return runtimeUrlInput.value || "http://localhost:32952";
+}
+
+export function setupLocalStorageRuntimeUrl() {
+  const runtimeUrlInput = document.getElementById("runtimeUrl");
+  const runtimeUrl = localStorage.getItem("runtimeUrl");
+  if (runtimeUrl) {
+    runtimeUrlInput.value = runtimeUrl;
+  }
+  runtimeUrlInput.addEventListener("change", () => {
+    localStorage.setItem("runtimeUrl", runtimeUrlInput.value);
+  });
+}

--- a/pocs/rest-client-flow.html
+++ b/pocs/rest-client-flow.html
@@ -51,13 +51,13 @@
     <script type="module">
       import { clearConsole, log } from "./js/poc-helpers.js";
       import * as H from "./js/poc-helpers.js";
-      import { mkFlatRestClient } from "@marlowe.io/runtime-rest-client";
+      import { mkRestClient } from "@marlowe.io/runtime-rest-client";
 
       let restClient = null;
       function getRestClient() {
         if (restClient === null) {
           const runtimeURL = H.getRuntimeUrl();
-          restClient = mkFlatRestClient(runtimeURL);
+          restClient = mkRestClient(runtimeURL);
         }
         return restClient;
       }

--- a/pocs/rest-client-flow.html
+++ b/pocs/rest-client-flow.html
@@ -23,23 +23,29 @@
       <h2>Request</h2>
       <div>
         <label for="parameter-json">Function parameters:</label>
-        <p>This should be filled with a JSON object that starts with an array, where each element is a numbered parameter.</p>
+        <p>
+          This should be filled with a JSON object that starts with an array,
+          where each element is a numbered parameter.
+        </p>
         <textarea
           id="parameter-json"
           type="text"
           style="width: 100%; height: 20em"
-        >[]</textarea>
+        >
+[]</textarea
+        >
       </div>
       <br />
       <input id="healthcheck" type="button" value="Healthcheck" />
       <br />
       <input id="get-contracts" type="button" value="Get Contracts" />
       <br />
+      <input id="get-contract-by-id" type="button" value="Get Contract by id" />
+      <br />
       <input id="create-contract" type="button" value="Create Contract" />
       <br />
       <input id="submit-contract" type="button" value="Submit Contract" />
       <br />
-
     </div>
 
     <h2>Console</h2>
@@ -79,13 +85,23 @@
         const restClient = getRestClient();
         const result = await restClient.getContracts(...getParams());
         // log(`Contracts: ${JSON.stringify(result)}`);
-        console.log("Contracts", result)
-        const nextRange = result.nextRange?.value ?? "-"
-        const prevRange = result.prevRange?.value ?? "-"
-        log(`Number of contracts in this range: ${result.headers.length} (full list in the browsers console)`);
+        console.log("Contracts", result);
+        const nextRange = result.nextRange?.value ?? "-";
+        const prevRange = result.prevRange?.value ?? "-";
+        log(
+          `Number of contracts in this range: ${result.headers.length} (full list in the browsers console)`
+        );
         log(`next range: ${nextRange}`);
         log(`prev range: ${prevRange}`);
-        log("<hr/>")
+        log("<hr/>");
+      }
+
+      async function getContractById() {
+        log(`Getting contract by id from ${H.getRuntimeUrl()}`);
+        const restClient = getRestClient();
+        const result = await restClient.getContractById(...getParams());
+        log(`Contract: ${JSONbig.stringify(result, null, 2)}`);
+        log("<hr/>");
       }
 
       async function createContract() {
@@ -103,13 +119,12 @@
         log(`Done`);
       }
 
-      async function healthcheck () {
+      async function healthcheck() {
         log(`Checking healthcheck on ${H.getRuntimeUrl()}`);
         const restClient = getRestClient();
         const result = await restClient.healthcheck();
         log(`Healthcheck result: ${JSON.stringify(result)}`);
-        log("<hr/>")
-
+        log("<hr/>");
       }
 
       H.setupLocalStorageRuntimeUrl();
@@ -125,6 +140,10 @@
 
       const submitContractButton = document.getElementById("submit-contract");
       submitContractButton.addEventListener("click", submitContract);
+
+      const getContractByIdButton =
+        document.getElementById("get-contract-by-id");
+      getContractByIdButton.addEventListener("click", getContractById);
 
       const clearConsoleButton = document.getElementById("clear-console");
       clearConsoleButton.addEventListener("click", clearConsole);

--- a/pocs/rest-client-flow.html
+++ b/pocs/rest-client-flow.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rest Client Flow</title>
+  </head>
+  <body>
+    <h1>Rest Client Flow</h1>
+    <div>
+      <h2>Setup Runtime</h2>
+
+      <label for="runtimeUrl">URL to a Marlowe Runtime instance:</label>
+      <input
+        id="runtimeUrl"
+        type="text"
+        autocomplete="on"
+        placeholder="http://localhost:32952"
+      />
+    </div>
+    <hr />
+    <div>
+      <h2>Request</h2>
+      <div>
+        <label for="parameter-json">Function parameters:</label>
+        <p>This should be filled with a JSON object that starts with an array, where each element is a numbered parameter.</p>
+        <textarea
+          id="parameter-json"
+          type="text"
+          style="width: 100%; height: 20em"
+        >[]</textarea>
+      </div>
+      <br />
+      <input id="healthcheck" type="button" value="Healthcheck" />
+      <br />
+      <input id="get-contracts" type="button" value="Get Contracts" />
+      <br />
+      <input id="create-contract" type="button" value="Create Contract" />
+      <br />
+      <input id="submit-contract" type="button" value="Submit Contract" />
+      <br />
+
+    </div>
+
+    <h2>Console</h2>
+    <div id="console"></div>
+    <input id="clear-console" type="button" value="Clear console" />
+
+    <script src="https://cdn.jsdelivr.net/npm/json-bigint-parser-browser@1.0.4/json-bigint-browser.min.js"></script>
+    <script src="/dist/local-importmap.js"></script>
+    <script type="module">
+      import { clearConsole, log } from "./js/poc-helpers.js";
+      import * as H from "./js/poc-helpers.js";
+      import { mkFlatRestClient } from "@marlowe.io/runtime-rest-client";
+
+      let restClient = null;
+      function getRestClient() {
+        if (restClient === null) {
+          const runtimeURL = H.getRuntimeUrl();
+          restClient = mkFlatRestClient(runtimeURL);
+        }
+        return restClient;
+      }
+      const runtimeUrlInput = document.getElementById("runtimeUrl");
+      runtimeUrlInput.addEventListener("change", () => {
+        restClient = null;
+      });
+
+      function getParams() {
+        const jsonParams = document.getElementById("parameter-json").value;
+        const params = JSON.parse(jsonParams);
+        if (!Array.isArray(params)) {
+          throw new Error("Parameters must be an array");
+        }
+        return params;
+      }
+      async function getContracts() {
+        log(`Getting contracts from ${H.getRuntimeUrl()}`);
+        const restClient = getRestClient();
+        const result = await restClient.getContracts(...getParams());
+        // log(`Contracts: ${JSON.stringify(result)}`);
+        console.log("Contracts", result)
+        const nextRange = result.nextRange?.value ?? "-"
+        const prevRange = result.prevRange?.value ?? "-"
+        log(`Number of contracts in this range: ${result.headers.length} (full list in the browsers console)`);
+        log(`next range: ${nextRange}`);
+        log(`prev range: ${prevRange}`);
+        log("<hr/>")
+      }
+
+      async function createContract() {
+        log(`Creating contract on ${H.getRuntimeUrl()}`);
+        const restClient = getRestClient();
+        const result = await restClient.createContract(...getParams());
+        log(`Contract id: ${result.contractId}`);
+        log(`Unsigned Tx: ${JSON.stringify(result.tx)}`);
+      }
+
+      async function submitContract() {
+        log(`Submitting contract on ${H.getRuntimeUrl()}`);
+        const restClient = getRestClient();
+        const result = await restClient.submitContract(...getParams());
+        log(`Done`);
+      }
+
+      async function healthcheck () {
+        log(`Checking healthcheck on ${H.getRuntimeUrl()}`);
+        const restClient = getRestClient();
+        const result = await restClient.healthcheck();
+        log(`Healthcheck result: ${JSON.stringify(result)}`);
+        log("<hr/>")
+
+      }
+
+      H.setupLocalStorageRuntimeUrl();
+
+      const healthcheckButton = document.getElementById("healthcheck");
+      healthcheckButton.addEventListener("click", healthcheck);
+
+      const getContractsButton = document.getElementById("get-contracts");
+      getContractsButton.addEventListener("click", getContracts);
+
+      const createContractButton = document.getElementById("create-contract");
+      createContractButton.addEventListener("click", createContract);
+
+      const submitContractButton = document.getElementById("submit-contract");
+      submitContractButton.addEventListener("click", submitContract);
+
+      const clearConsoleButton = document.getElementById("clear-console");
+      clearConsoleButton.addEventListener("click", clearConsole);
+    </script>
+  </body>
+</html>

--- a/pocs/run-lite.html
+++ b/pocs/run-lite.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Marlowe Run Very Lite POC</title>
+  </head>
+  <body>
+    <h1>Marlowe Run Lite Lite</h1>
+    <div>
+      <h2>1. Setup contract and Runtime</h2>
+
+      <label for="runtimeUrl">URL to a Marlowe Runtime instance:</label>
+      <input
+        id="runtimeUrl"
+        type="text"
+        autocomplete="on"
+        placeholder="http://localhost:32952"
+      />
+      <br />
+      <label for="wallet">Select wallet:</label>
+      <select id="wallet" name="wallet">
+        <option value="nami">Nami</option>
+        <option value="eternl">Eternl</option>
+      </select>
+      <div>
+        <h3>1.1 Create contract</h3>
+        <label for="contract">JSON Contract:</label>
+        <textarea id="contract" type="text" style="width: 100%; height: 20em">
+"close"</textarea
+        >
+      </div>
+      <br />
+      <input id="create-contract" type="button" value="Create contract" />
+    </div>
+    <div>
+      <h3>1.2 Load contract</h3>
+      <label for="contract-id">Contract ID:</label>
+      <input id="contract-id" type="text" />
+    </div>
+    <hr />
+    <div>
+      <h2>2. Run contract</h2>
+      <i>ContractId</i>: <a id="contract-id-indicator">-</a>
+      <h4>Actions</h4>
+      <br />
+      <div>
+        <div>
+          Deposit
+          <input type="number" id="deposit-amount" value="0" />
+          of token with policy id
+          <input type="text" id="deposit-policy-id" />
+          and token name
+          <input type="text" id="deposit-token-name" />
+          into account of
+          <select id="deposit-into-type">
+            <option value="address">Address</option>
+            <!--option value="role">Role</option-->
+          </select>
+          <input type="text" id="deposit-token-name" />
+          <input id="deposit" type="button" value="Deposit" />
+        </div>
+        <div>Choice</div>
+        <div>Notify</div>
+      </div>
+    </div>
+
+    <h2>Console</h2>
+    <div id="console"></div>
+    <input id="clear-console" type="button" value="Clear console" />
+
+    <script src="/dist/local-importmap.js"></script>
+    <script type="module">
+      import { clearConsole, log } from "./js/poc-helpers.js";
+      import * as H from "./js/poc-helpers.js";
+      import { Browser } from "@marlowe.io/runtime-lifecycle";
+      import { getAddressesAndCollaterals } from "@marlowe.io/wallet/api";
+
+      window.Browser = Browser;
+      window.wallet = getAddressesAndCollaterals;
+      const consoleDiv = document.getElementById("console");
+
+      function setContractIdIndicator(contractId) {
+        const contractIdIndicator = document.getElementById(
+          "contract-id-indicator"
+        );
+        contractIdIndicator.innerHTML = contractId;
+        // TODO: Add a network selector
+        const url = `https://preprod.marlowescan.com/contractView?tab=state&contractId=${contractId.replace(
+          "#",
+          "%23"
+        )}`;
+        contractIdIndicator.href = url;
+        contractIdIndicator.target = "_blank";
+      }
+
+      async function createContract() {
+        const runtimeUrlInput = document.getElementById("runtimeUrl");
+        const runtimeURL = runtimeUrlInput.value || "http://localhost:32952";
+        const walletInput = document.getElementById("wallet");
+        const walletName = walletInput.value;
+        const contractInput = document.getElementById("contract");
+        const contract = JSON.parse(contractInput.value);
+
+        const runtime = await Browser.mkRuntimeLifecycle({
+          runtimeURL,
+          walletName,
+        });
+
+        const contractId = await runtime.contracts.create({ contract });
+        log("Contract created with id: " + contractId);
+        setContractIdIndicator(contractId);
+      }
+
+      H.setupLocalStorageRuntimeUrl();
+
+      const createContractButton = document.getElementById("create-contract");
+      createContractButton.addEventListener("click", createContract);
+
+      const clearConsoleButton = document.getElementById("clear-console");
+      clearConsoleButton.addEventListener("click", clearConsole);
+    </script>
+  </body>
+</html>

--- a/pocs/wallet-flow.html
+++ b/pocs/wallet-flow.html
@@ -18,9 +18,8 @@
         type="text"
         style="width: 100%; height: 20em"
       ></textarea>
-    <input id="sign-tx" type="button" value="Sign tx" />
-    <br />
-
+      <input id="sign-tx" type="button" value="Sign tx" />
+      <br />
     </div>
     <hr />
 
@@ -28,10 +27,7 @@
     <script src="/dist/local-importmap.js"></script>
     <script type="module">
       import { clearConsole, log } from "./js/poc-helpers.js";
-      import {
-        mkBrowserWallet,
-        getAvailableWallets,
-      } from "@marlowe.io/wallet";
+      import { mkBrowserWallet, getAvailableWallets } from "@marlowe.io/wallet";
 
       const walletInput = document.getElementById("wallet");
       const availableWallets = getAvailableWallets();

--- a/pocs/wallet-flow.html
+++ b/pocs/wallet-flow.html
@@ -10,13 +10,29 @@
     <select id="wallet" name="wallet"></select>
     <br />
     <input id="start-flow" type="button" value="Start flow" />
-    <hr />
-    <div id="console"></div>
-    <script src="/dist/jsdelivr-gh-importmap.js"></script>
-    <script type="module">
-      import { mkBrowserWallet, getAvailableWallets } from "@marlowe.io/wallet";
+    <br />
+    <div>
+      <label for="unsigned-tx">Unsigned TX:</label>
+      <textarea
+        id="unsigned-tx"
+        type="text"
+        style="width: 100%; height: 20em"
+      ></textarea>
+    <input id="sign-tx" type="button" value="Sign tx" />
+    <br />
 
-      const consoleDiv = document.getElementById("console");
+    </div>
+    <hr />
+
+    <div id="console"></div>
+    <script src="/dist/local-importmap.js"></script>
+    <script type="module">
+      import { clearConsole, log } from "./js/poc-helpers.js";
+      import {
+        mkBrowserWallet,
+        getAvailableWallets,
+      } from "@marlowe.io/wallet";
+
       const walletInput = document.getElementById("wallet");
       const availableWallets = getAvailableWallets();
       if (availableWallets.length === 0) {
@@ -35,14 +51,8 @@
         });
       }
 
-      const log = (message) => {
-        var currentContent = consoleDiv.innerHTML;
-        consoleDiv.innerHTML = currentContent + "<\BR>" + message;
-      };
-
       async function cip30Flow() {
-        // Clear console
-        consoleDiv.innerHTML = "";
+        clearConsole();
 
         const walletName = walletInput.value;
 
@@ -99,8 +109,22 @@
         log("Wallet flow done 🎉");
       }
 
+      async function signTx() {
+        const walletName = walletInput.value;
+
+        log(`<h2>Accessing ${walletName} Wallet Extension</h2>`);
+        const wallet = await createBrowserWallet(walletName);
+        const unsignedTx = document.getElementById("unsigned-tx").value;
+        const signed = await wallet.signTxTheCIP30Way(unsignedTx);
+        log(`<h2>Signed TX</h2>`);
+        log(signed);
+      }
+
       const startFlowButton = document.getElementById("start-flow");
       startFlowButton.addEventListener("click", cip30Flow);
+
+      const signTxButton = document.getElementById("sign-tx");
+      signTxButton.addEventListener("click", signTx);
     </script>
   </body>
 </html>

--- a/typedoc.json
+++ b/typedoc.json
@@ -14,7 +14,7 @@
   },
   "externalSymbolLinkMappings": {
     "global": {
-      "io-ts-usage": "https://github.com/gcanti/io-ts/blob/master/index.md#basic-usage",
+      "io-ts-usage": "https://github.com/gcanti/io-ts/blob/master/index.md#basic-usage"
     }
   }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -4,5 +4,17 @@
   "entryPointStrategy": "packages",
   "out": "./docs",
   "readme": "./packages/api.md",
-  "includeVersion": true
+  "includeVersion": true,
+  "sidebarLinks": {
+    "How to develop": "https://github.com/input-output-hk/marlowe-ts-sdk/blob/main/doc/howToDevelop.md",
+    "Module system": "https://github.com/input-output-hk/marlowe-ts-sdk/blob/main/doc/modules-system.md"
+  },
+  "navigationLinks": {
+    "Github Repo": "https://github.com/input-output-hk/marlowe-ts-sdk"
+  },
+  "externalSymbolLinkMappings": {
+    "global": {
+      "io-ts-usage": "https://github.com/gcanti/io-ts/blob/master/index.md#basic-usage",
+    }
+  }
 }


### PR DESCRIPTION
This PR partially removes FP-TS from the TS-SDK runtime-rest-client by creating an alternative Flat API that closely resembles the backend documentation.

It is partially removed because I've only removed it from the request side, not from the response. The reason is that I would have to cascade too many changes in the codebase and the time to do this is restricted.

