### PR TITLE
Language core v1 exports refactor

### DIFF
--- a/changelog.d/20231003_132653_hrajchert_PLT_7500_compatibility_layer.md
+++ b/changelog.d/20231003_132653_hrajchert_PLT_7500_compatibility_layer.md
@@ -1,4 +1,3 @@
-
 ### @marlowe.io/language-core-v1
 
 - BREAKING CHANGE: Modify the exported modules to have the JSON types in the main export and the runtime validations under a `/guards` module.

--- a/changelog.d/20231003_132653_hrajchert_PLT_7500_compatibility_layer.md
+++ b/changelog.d/20231003_132653_hrajchert_PLT_7500_compatibility_layer.md
@@ -1,0 +1,4 @@
+
+### @marlowe.io/language-core-v1
+
+- BREAKING CHANGE: Modify the exported modules to have the JSON types in the main export and the runtime validations under a `/guards` module.

--- a/jsdelivr-npm-importmap.js
+++ b/jsdelivr-npm-importmap.js
@@ -1,53 +1,53 @@
 const importMap = {
   imports: {
     "@marlowe.io/adapter":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/adapter.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/adapter.js",
     "@marlowe.io/adapter/codec":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/codec.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/codec.js",
     "@marlowe.io/adapter/file":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/file.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/file.js",
     "@marlowe.io/adapter/fp-ts":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/fp-ts.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/fp-ts.js",
     "@marlowe.io/adapter/http":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/http.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/http.js",
     "@marlowe.io/adapter/time":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/time.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/time.js",
     "@marlowe.io/language-core-v1":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-3/dist/bundled/esm/language-core-v1.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-4/dist/bundled/esm/language-core-v1.js",
     "@marlowe.io/language-core-v1/guards":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-3/dist/bundled/esm/guards.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-4/dist/bundled/esm/guards.js",
     "@marlowe.io/language-core-v1/next":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-3/dist/bundled/esm/next.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-4/dist/bundled/esm/next.js",
     "@marlowe.io/language-core-v1/version":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-3/dist/bundled/esm/version.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-4/dist/bundled/esm/version.js",
     "@marlowe.io/language-examples":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-examples@0.2.0-alpha-3/dist/bundled/esm/language-examples.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-examples@0.2.0-alpha-4/dist/bundled/esm/language-examples.js",
     "@marlowe.io/token-metadata-client":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/token-metadata-client@0.2.0-alpha-3/dist/bundled/esm/token-metadata-client.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/token-metadata-client@0.2.0-alpha-4/dist/bundled/esm/token-metadata-client.js",
     "@marlowe.io/wallet":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-3/dist/bundled/esm/wallet.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-4/dist/bundled/esm/wallet.js",
     "@marlowe.io/wallet/api":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-3/dist/bundled/esm/api.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-4/dist/bundled/esm/api.js",
     "@marlowe.io/wallet/browser":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-3/dist/bundled/esm/browser.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-4/dist/bundled/esm/browser.js",
     "@marlowe.io/wallet/nodejs":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-3/dist/bundled/esm/nodejs.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-4/dist/bundled/esm/nodejs.js",
     "@marlowe.io/runtime-rest-client":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-3/dist/bundled/esm/runtime-rest-client.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-4/dist/bundled/esm/runtime-rest-client.js",
     "@marlowe.io/runtime-rest-client/transaction":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-3/dist/bundled/esm/transaction.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-4/dist/bundled/esm/transaction.js",
     "@marlowe.io/runtime-rest-client/withdrawal":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-3/dist/bundled/esm/withdrawal.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-4/dist/bundled/esm/withdrawal.js",
     "@marlowe.io/runtime-core":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-core@0.2.0-alpha-3/dist/bundled/esm/runtime-core.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-core@0.2.0-alpha-4/dist/bundled/esm/runtime-core.js",
     "@marlowe.io/runtime-lifecycle":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-3/dist/bundled/esm/runtime-lifecycle.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-4/dist/bundled/esm/runtime-lifecycle.js",
     "@marlowe.io/runtime-lifecycle/api":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-3/dist/bundled/esm/api.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-4/dist/bundled/esm/api.js",
     "@marlowe.io/runtime-lifecycle/browser":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-3/dist/bundled/esm/browser.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-4/dist/bundled/esm/browser.js",
     "@marlowe.io/runtime-lifecycle/generic":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-3/dist/bundled/esm/generic.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-4/dist/bundled/esm/generic.js",
     "lucid-cardano": "https://unpkg.com/lucid-cardano@0.10.7/web/mod.js",
   },
 };

--- a/jsdelivr-npm-importmap.js
+++ b/jsdelivr-npm-importmap.js
@@ -1,51 +1,53 @@
 const importMap = {
   imports: {
     "@marlowe.io/adapter":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/adapter.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/adapter.js",
     "@marlowe.io/adapter/codec":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/codec.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/codec.js",
     "@marlowe.io/adapter/file":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/file.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/file.js",
     "@marlowe.io/adapter/fp-ts":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/fp-ts.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/fp-ts.js",
     "@marlowe.io/adapter/http":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/http.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/http.js",
     "@marlowe.io/adapter/time":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-4/dist/bundled/esm/time.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/adapter@0.2.0-alpha-3/dist/bundled/esm/time.js",
     "@marlowe.io/language-core-v1":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-4/dist/bundled/esm/language-core-v1.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-3/dist/bundled/esm/language-core-v1.js",
+    "@marlowe.io/language-core-v1/guards":
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-3/dist/bundled/esm/guards.js",
     "@marlowe.io/language-core-v1/next":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-4/dist/bundled/esm/next.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-3/dist/bundled/esm/next.js",
     "@marlowe.io/language-core-v1/version":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-4/dist/bundled/esm/version.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-core-v1@0.2.0-alpha-3/dist/bundled/esm/version.js",
     "@marlowe.io/language-examples":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-examples@0.2.0-alpha-4/dist/bundled/esm/language-examples.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/language-examples@0.2.0-alpha-3/dist/bundled/esm/language-examples.js",
     "@marlowe.io/token-metadata-client":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/token-metadata-client@0.2.0-alpha-4/dist/bundled/esm/token-metadata-client.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/token-metadata-client@0.2.0-alpha-3/dist/bundled/esm/token-metadata-client.js",
     "@marlowe.io/wallet":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-4/dist/bundled/esm/wallet.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-3/dist/bundled/esm/wallet.js",
     "@marlowe.io/wallet/api":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-4/dist/bundled/esm/api.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-3/dist/bundled/esm/api.js",
     "@marlowe.io/wallet/browser":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-4/dist/bundled/esm/browser.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-3/dist/bundled/esm/browser.js",
     "@marlowe.io/wallet/nodejs":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-4/dist/bundled/esm/nodejs.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/wallet@0.2.0-alpha-3/dist/bundled/esm/nodejs.js",
     "@marlowe.io/runtime-rest-client":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-4/dist/bundled/esm/runtime-rest-client.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-3/dist/bundled/esm/runtime-rest-client.js",
     "@marlowe.io/runtime-rest-client/transaction":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-4/dist/bundled/esm/transaction.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-3/dist/bundled/esm/transaction.js",
     "@marlowe.io/runtime-rest-client/withdrawal":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-4/dist/bundled/esm/withdrawal.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-rest-client@0.2.0-alpha-3/dist/bundled/esm/withdrawal.js",
     "@marlowe.io/runtime-core":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-core@0.2.0-alpha-4/dist/bundled/esm/runtime-core.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-core@0.2.0-alpha-3/dist/bundled/esm/runtime-core.js",
     "@marlowe.io/runtime-lifecycle":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-4/dist/bundled/esm/runtime-lifecycle.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-3/dist/bundled/esm/runtime-lifecycle.js",
     "@marlowe.io/runtime-lifecycle/api":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-4/dist/bundled/esm/api.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-3/dist/bundled/esm/api.js",
     "@marlowe.io/runtime-lifecycle/browser":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-4/dist/bundled/esm/browser.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-3/dist/bundled/esm/browser.js",
     "@marlowe.io/runtime-lifecycle/generic":
-      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-4/dist/bundled/esm/generic.js",
+      "https:/cdn.jsdelivr.net/npm/@marlowe.io/runtime-lifecycle@0.2.0-alpha-3/dist/bundled/esm/generic.js",
     "lucid-cardano": "https://unpkg.com/lucid-cardano@0.10.7/web/mod.js",
   },
 };

--- a/packages/adapter/src/time.ts
+++ b/packages/adapter/src/time.ts
@@ -8,6 +8,8 @@ export const ISO8601 = t.string;
 export type POSIXTime = t.TypeOf<typeof POSIXTime>;
 export const POSIXTime = t.number;
 
+export const posixTimeToIso8601 = (posixTime: POSIXTime): ISO8601 =>
+  datetoIso8601(new Date(posixTime));
 export const datetoIso8601 = (date: Date): ISO8601 => date.toISOString();
 
 // a minute in milliseconds

--- a/packages/api.md
+++ b/packages/api.md
@@ -2,11 +2,11 @@ The **Marlowe TS-SDK** is a suite of _TypeScript/JavaScript_ libraries for devel
 
 It is composed of the following packages:
 
-| Package | Description |
-| --- | --- |
-| [@marlowe.io/language-core-v1](./modules/_marlowe_io_language_core_v1.html) | Provides constructors and serialization utilities for the types defined in the [Marlowe Core specification](https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf)  |
-| [@marlowe.io/wallet](./modules/_marlowe_io_wallet.html) | Defines an API of what Marlowe needs from a Wallet and provides a CIP30 implementation |
-| [@marlowe.io/runtime-core](./modules/_marlowe_io_runtime_core.html) | Core domain concepts used throughout the runtime libraries. |
-| [@marlowe.io/runtime-rest-client](./modules/_marlowe_io_runtime_rest_client.html) | 1 to 1 mapping of the [Runtime Rest API](https://docs.marlowe.iohk.io/api/introduction). |
-| [@marlowe.io/runtime-lifecycle](./modules/_marlowe_io_runtime_lifecycle.html) | High level API that captures the life of "your" contracts. It builds upon the `wallet` and `runtime-rest-client` to solve common use cases |
-| [@marlowe.io/adapter](./modules/_marlowe_io_adapter.html) | Supporting set of libraries for Marlowe and Runtime Core Domains. |
+| Package                                                                           | Description                                                                                                                                                                              |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@marlowe.io/language-core-v1](./modules/_marlowe_io_language_core_v1.html)       | Provides constructors and serialization utilities for the types defined in the [Marlowe Core specification](https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf) |
+| [@marlowe.io/wallet](./modules/_marlowe_io_wallet.html)                           | Defines an API of what Marlowe needs from a Wallet and provides a CIP30 implementation                                                                                                   |
+| [@marlowe.io/runtime-core](./modules/_marlowe_io_runtime_core.html)               | Core domain concepts used throughout the runtime libraries.                                                                                                                              |
+| [@marlowe.io/runtime-rest-client](./modules/_marlowe_io_runtime_rest_client.html) | 1 to 1 mapping of the [Runtime Rest API](https://docs.marlowe.iohk.io/api/introduction).                                                                                                 |
+| [@marlowe.io/runtime-lifecycle](./modules/_marlowe_io_runtime_lifecycle.html)     | High level API that captures the life of "your" contracts. It builds upon the `wallet` and `runtime-rest-client` to solve common use cases                                               |
+| [@marlowe.io/adapter](./modules/_marlowe_io_adapter.html)                         | Supporting set of libraries for Marlowe and Runtime Core Domains.                                                                                                                        |

--- a/packages/language/core/v1/Readme.md
+++ b/packages/language/core/v1/Readme.md
@@ -1,12 +1,14 @@
 # Description
 
-This package contains code to work with the version 1 of Marlowe Core.
+This package contains code to work with the version 1 of Marlowe Core. It exports three modules:
 
-TODO: PLT-7500 create compatibility API to work with the Playgrounds interface.
+- @{@link index | marlowe.io/language-core-v1} - Exports static types (TypeScript only) for the JSON schema as specified in the Appendix E of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe specification}
+- @{@link guards | marlowe.io/language-core-v1/guards} - Exports {@link !io-ts-usage | Dynamic type guards} (both JavaScript and TypeScript) for the same schema. These are used to validate the JSON objects at runtime.
+- @{@link next | marlowe.io/language-core-v1/next} - Exports types to ask for _next_ applicable inputs for a Marlowe Contract.
 
 ## Getting started
 
-The `@marlowe.io/language-core-v1` package is [released as an ESM module](https://github.com/input-output-hk/marlowe-ts-sdk/blob/main/doc/modules-system.md) and can be used with a modern bundler or imported directly in the browser (without any bundler) as long as you use an import map.
+This package is [released as an ESM module](https://github.com/input-output-hk/marlowe-ts-sdk/blob/main/doc/modules-system.md) and can be used with a modern bundler or imported directly in the browser (without any bundler) as long as you use an import map.
 
 ### Browser
 
@@ -15,9 +17,14 @@ The `@marlowe.io/language-core-v1` package is [released as an ESM module](https:
   <body>
     <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
     <script type="module">
-      import * as C from "@marlowe.io/language-core-v1";
-      console.log("TODO", C);
-      debugger;
+      import { Contract } from "@marlowe.io/language-core-v1/guards";
+      const jsonObject = JSON.parse(httpResponse);
+
+      if (Contract.is(jsonObject)) {
+        // The jsonObject respects the JSON schema for Contract
+      } else {
+        // The jsonObject does not respect the JSON schema for Contract
+      }
     </script>
   </body>
 </html>

--- a/packages/language/core/v1/package.json
+++ b/packages/language/core/v1/package.json
@@ -35,6 +35,11 @@
       "require": "./dist/bundled/cjs/next.cjs",
       "types": "./dist/esm/next/index.d.ts"
     },
+    "./guards": {
+      "import": "./dist/esm/guards.js",
+      "require": "./dist/bundled/cjs/guards.cjs",
+      "types": "./dist/esm/guards.d.ts"
+    },
     "./version": {
       "import": "./dist/esm/version.js",
       "require": "./dist/bundled/cjs/version.cjs",

--- a/packages/language/core/v1/src/actions.ts
+++ b/packages/language/core/v1/src/actions.ts
@@ -1,46 +1,83 @@
 import * as t from "io-ts/lib/index.js";
 
-import { Observation } from "./value-and-observation.js";
-import { ChoiceId } from "./value-and-observation.js";
-import { Party } from "./participants.js";
-import { AccountId } from "./payee.js";
-import { Token } from "./token.js";
-import { Value } from "./value-and-observation.js";
+import {
+  Observation,
+  ObservationGuard,
+  Value,
+} from "./value-and-observation.js";
+import { ChoiceId, ChoiceIdGuard } from "./choices.js";
+import { Party, PartyGuard } from "./participants.js";
+import { AccountId, AccountIdGuard } from "./payee.js";
+import { Token, TokenGuard } from "./token.js";
+import { ValueGuard } from "./value-and-observation.js";
+import { Bound, BoundGuard } from "./choices.js";
 
-export type Bound = { from: bigint; to: bigint };
+/**
+ * TODO: Comment
+ * @category Action
+ */
+export interface Choice {
+  choose_between: Bound[];
+  for_choice: ChoiceId;
+}
 
-export const Bound: t.Type<Bound> = t.recursion("Bound", () =>
-  t.type({ from: t.bigint, to: t.bigint })
+// TODO: Try to remove recursion
+/**
+ * TODO: Comment
+ * @category Action
+ */
+export const ChoiceGuard: t.Type<Choice> = t.recursion("Choice", () =>
+  t.type({ choose_between: t.array(BoundGuard), for_choice: ChoiceIdGuard })
 );
 
-export type Choice = { choose_between: Bound[]; for_choice: ChoiceId };
-
-export const Choice: t.Type<Choice> = t.recursion("Choice", () =>
-  t.type({ choose_between: t.array(Bound), for_choice: ChoiceId })
-);
-
-export type Deposit = {
+/**
+ * TODO: Comment
+ * @category Action
+ */
+export interface Deposit {
   party: Party;
   deposits: Value;
   of_token: Token;
   into_account: AccountId;
-};
+}
 
-export const Deposit: t.Type<Deposit> = t.type({
-  party: Party,
-  deposits: Value,
-  of_token: Token,
-  into_account: AccountId,
+/**
+ * TODO: Comment
+ * @category Action
+ */
+export const DepositGuard: t.Type<Deposit> = t.type({
+  party: PartyGuard,
+  deposits: ValueGuard,
+  of_token: TokenGuard,
+  into_account: AccountIdGuard,
 });
 
-export type Notify = { notify_if: Observation };
+/**
+ * TODO: Comment
+ * @category Action
+ */
+export interface Notify {
+  notify_if: Observation;
+}
 
-export const Notify: t.Type<Notify> = t.recursion("Notify", () =>
-  t.type({ notify_if: Observation })
+/**
+ * TODO: Comment
+ * @category Action
+ */
+export const NotifyGuard: t.Type<Notify> = t.recursion("Notify", () =>
+  t.type({ notify_if: ObservationGuard })
 );
 
+/**
+ * TODO: Comment
+ * @category Action
+ */
 export type Action = Deposit | Choice | Notify;
 
-export const Action: t.Type<Action> = t.recursion("Action", () =>
-  t.union([Deposit, Choice, Notify])
+/**
+ * TODO: Comment
+ * @category Action
+ */
+export const ActionGuard: t.Type<Action> = t.recursion("Action", () =>
+  t.union([DepositGuard, ChoiceGuard, NotifyGuard])
 );

--- a/packages/language/core/v1/src/choices.ts
+++ b/packages/language/core/v1/src/choices.ts
@@ -1,0 +1,62 @@
+import * as t from "io-ts/lib/index.js";
+import { Party, PartyGuard } from "./participants.js";
+
+/**
+ * TODO: Comment
+ * @category Choice
+ */
+export type ChoiceName = string;
+
+/**
+ * TODO: Comment
+ * @category Choice
+ */
+export const ChoiceNameGuard: t.Type<ChoiceName> = t.string;
+
+/**
+ * TODO: Comment
+ * @category Choice
+ */
+export interface ChoiceId {
+  choice_name: ChoiceName;
+  choice_owner: Party;
+}
+
+/**
+ * TODO: Comment
+ * @category Choice
+ */
+export const ChoiceIdGuard: t.Type<ChoiceId> = t.type({
+  choice_name: ChoiceNameGuard,
+  choice_owner: PartyGuard,
+});
+
+/**
+ * TODO: Comment
+ * @category Choice
+ */
+export interface Bound {
+  from: bigint;
+  to: bigint;
+}
+
+// TODO: Try to remove recursion
+/**
+ * TODO: Comment
+ * @category Choice
+ */
+export const BoundGuard: t.Type<Bound> = t.recursion("Bound", () =>
+  t.type({ from: t.bigint, to: t.bigint })
+);
+
+/**
+ * TODO: Comment
+ * @category Choice
+ */
+export type ChosenNum = bigint;
+
+/**
+ * TODO: Comment
+ * @category Choice
+ */
+export const ChosenNumGuard: t.Type<ChosenNum> = t.bigint;

--- a/packages/language/core/v1/src/contract.ts
+++ b/packages/language/core/v1/src/contract.ts
@@ -235,6 +235,7 @@ export const datetoTimeout = (date: Date): Timeout =>
  */
 export const timeoutToDate = (timeout: Timeout): Date =>
   new Date(Number(timeout));
+
 export type Contract = Close | Pay | If | When | Let | Assert;
 
 /**

--- a/packages/language/core/v1/src/contract.ts
+++ b/packages/language/core/v1/src/contract.ts
@@ -1,17 +1,42 @@
 import * as t from "io-ts/lib/index.js";
-import { Observation } from "./value-and-observation.js";
-import { AccountId } from "./payee.js";
-import { Payee } from "./payee.js";
-import { Token } from "./token.js";
-import { Value, ValueId } from "./value-and-observation.js";
-import { Action } from "./actions.js";
+import {
+  Observation,
+  ObservationGuard,
+  Value,
+  ValueId,
+} from "./value-and-observation.js";
+import { AccountId, AccountIdGuard, Payee } from "./payee.js";
+import { PayeeGuard } from "./payee.js";
+import { Token, TokenGuard } from "./token.js";
+import { ValueGuard, ValueIdGuard } from "./value-and-observation.js";
+import { Action, ActionGuard } from "./actions.js";
 import { pipe } from "fp-ts/lib/function.js";
 import getUnixTime from "date-fns/getUnixTime/index.js";
 
+/**
+ * Search [[lower-name-builders]]
+ * @hidden
+ */
 export const close = "close";
-export type Close = t.TypeOf<typeof Close>;
-export const Close = t.literal("close");
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export type Close = "close";
 
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export const CloseGuard: t.Type<Close> = t.literal("close");
+
+/**
+ * @hidden
+ */
+//
+// [[lower-name-builders]] DISCUSSION:
+//     What should we do with the lower case constructors? close, pay, role, etc... There are some that are impossible to
+//     make, for example `let` and `if` which are reserved words in JS. For the moment I'm hidding them from the API.
 export const pay = (
   pay: Value,
   token: Token,
@@ -26,65 +51,176 @@ export const pay = (
   then: then,
 });
 
-export type Pay = {
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export interface Pay {
   pay: Value;
   token: Token;
   from_account: AccountId;
   to: Payee;
   then: Contract;
-};
+}
 
-export const Pay = t.recursion<Pay>("Pay", () =>
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export const PayGuard = t.recursion<Pay>("Pay", () =>
   t.type({
-    pay: Value,
-    token: Token,
-    from_account: AccountId,
-    to: Payee,
-    then: Contract,
+    pay: ValueGuard,
+    token: TokenGuard,
+    from_account: AccountIdGuard,
+    to: PayeeGuard,
+    then: ContractGuard,
   })
 );
 
-export type If = { if: Observation; then: Contract; else: Contract };
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export interface If {
+  /**
+   * TODO: Comment
+   */
+  if: Observation;
+  /**
+   * TODO: Comment
+   */
+  then: Contract;
+  /**
+   * TODO: Comment
+   */
+  else: Contract;
+}
 
-export const If: t.Type<If> = t.recursion("If", () =>
-  t.type({ if: Observation, then: Contract, else: Contract })
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export const IfGuard: t.Type<If> = t.recursion("If", () =>
+  t.type({ if: ObservationGuard, then: ContractGuard, else: ContractGuard })
 );
 
-export type Let = { let: ValueId; be: Value; then: Contract };
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export interface Let {
+  /**
+   * TODO: Comment
+   */
+  let: ValueId;
+  /**
+   * TODO: Comment
+   */
+  be: Value;
+  /**
+   * TODO: Comment
+   */
+  then: Contract;
+}
 
-export const Let: t.Type<Let> = t.recursion("Let", () =>
-  t.type({ let: ValueId, be: Value, then: Contract })
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export const LetGuard: t.Type<Let> = t.recursion("Let", () =>
+  t.type({ let: ValueIdGuard, be: ValueGuard, then: ContractGuard })
 );
 
-export type Assert = { assert: Observation; then: Contract };
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export interface Assert {
+  /**
+   * TODO: Comment
+   */
+  assert: Observation;
+  /**
+   * TODO: Comment
+   */
+  then: Contract;
+}
 
-export const Assert: t.Type<Assert> = t.recursion("Assert", () =>
-  t.type({ assert: Observation, then: Contract })
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export const AssertGuard: t.Type<Assert> = t.recursion("Assert", () =>
+  t.type({ assert: ObservationGuard, then: ContractGuard })
 );
 
-export type When = {
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export interface When {
+  /**
+   * TODO: Comment
+   */
   when: Case[];
+  /**
+   * TODO: Comment
+   */
   timeout: Timeout;
+  /**
+   * TODO: Comment
+   */
   timeout_continuation: Contract;
-};
-
-export const When: t.Type<When> = t.recursion("When", () =>
+}
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export const WhenGuard: t.Type<When> = t.recursion("When", () =>
   t.type({
-    when: t.array(Case),
-    timeout: Timeout,
-    timeout_continuation: Contract,
+    when: t.array(CaseGuard),
+    timeout: TimeoutGuard,
+    timeout_continuation: ContractGuard,
   })
 );
 
-export type Case = { case: Action; then: Contract };
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export interface Case {
+  /**
+   * TODO: Comment
+   */
+  case: Action;
+  /**
+   * TODO: Comment
+   */
+  then: Contract;
+}
 
-export const Case: t.Type<Case> = t.recursion("Case", () =>
-  t.type({ case: Action, then: Contract })
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export const CaseGuard: t.Type<Case> = t.recursion("Case", () =>
+  t.type({ case: ActionGuard, then: ContractGuard })
 );
 
-export type Timeout = t.TypeOf<typeof Timeout>;
-export const Timeout = t.bigint;
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export type Timeout = bigint;
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export const TimeoutGuard: t.Type<Timeout> = t.bigint;
 
+/**
+ * @hidden
+ */
 export const datetoTimeout = (date: Date): Timeout =>
   pipe(
     date,
@@ -94,11 +230,17 @@ export const datetoTimeout = (date: Date): Timeout =>
     (a) => a.valueOf()
   );
 
+/**
+ * @hidden
+ */
 export const timeoutToDate = (timeout: Timeout): Date =>
   new Date(Number(timeout));
-
 export type Contract = Close | Pay | If | When | Let | Assert;
 
-export const Contract: t.Type<Contract> = t.recursion("Contract", () =>
-  t.union([Close, Pay, If, When, Let, Assert])
+/**
+ * TODO: Comment
+ * @category Contract
+ */
+export const ContractGuard: t.Type<Contract> = t.recursion("Contract", () =>
+  t.union([CloseGuard, PayGuard, IfGuard, WhenGuard, LetGuard, AssertGuard])
 );

--- a/packages/language/core/v1/src/environment.ts
+++ b/packages/language/core/v1/src/environment.ts
@@ -13,7 +13,7 @@ export const mkEnvironment =
 
 /**
  * TODO: Comment
- * @see Appendix E.16 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @see Appendix E.16 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe specification}
  * @category Environment
  */
 export interface TimeInterval {
@@ -23,7 +23,7 @@ export interface TimeInterval {
 
 /**
  * TODO: Comment
- * @see Appendix E.16 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @see Appendix E.16 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe specification}
  * @category Environment
  */
 export const TimeIntervalGuard: t.Type<TimeInterval> = t.type({
@@ -33,7 +33,7 @@ export const TimeIntervalGuard: t.Type<TimeInterval> = t.type({
 
 /**
  * TODO: Comment
- * @see Section 2.1.10 and appendix E.22 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @see Section 2.1.10 and appendix E.22 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe specification}
  * @category Environment
  */
 export interface Environment {
@@ -42,7 +42,7 @@ export interface Environment {
 
 /**
  * TODO: Comment
- * @see Section 2.1.10 and appendix E.22 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @see Section 2.1.10 and appendix E.22 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe specification}
  * @category Environment
  */
 export const EnvironmentGuard: t.Type<Environment> = t.type({

--- a/packages/language/core/v1/src/environment.ts
+++ b/packages/language/core/v1/src/environment.ts
@@ -1,15 +1,50 @@
 import * as t from "io-ts/lib/index.js";
-import { ISO8601, datetoIso8601 } from "@marlowe.io/adapter/time";
+import { ISO8601, datetoIso8601, POSIXTime } from "@marlowe.io/adapter/time";
 
-export const mkEnvironment: (
-  validityStart: Date
-) => (validityEnd: Date) => Environment = (start) => (end) => ({
-  validityStart: datetoIso8601(start),
-  validityEnd: datetoIso8601(end),
+/**
+ * @hidden
+ */
+// TODO: If this is supposed to be used by the end user it should be uncurried
+export const mkEnvironment =
+  (start: Date) =>
+  (end: Date): Environment => ({
+    timeInterval: { from: start.getTime(), to: end.getTime() },
+  });
+
+/**
+ * TODO: Comment
+ * @see Appendix E.16 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category Environment
+ */
+export interface TimeInterval {
+  from: POSIXTime;
+  to: POSIXTime;
+}
+
+/**
+ * TODO: Comment
+ * @see Appendix E.16 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category Environment
+ */
+export const TimeIntervalGuard: t.Type<TimeInterval> = t.type({
+  from: POSIXTime,
+  to: POSIXTime,
 });
 
-export type Environment = t.TypeOf<typeof Environment>;
-export const Environment = t.type({
-  validityStart: ISO8601,
-  validityEnd: ISO8601,
+/**
+ * TODO: Comment
+ * @see Section 2.1.10 and appendix E.22 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category Environment
+ */
+export interface Environment {
+  timeInterval: TimeInterval;
+}
+
+/**
+ * TODO: Comment
+ * @see Section 2.1.10 and appendix E.22 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category Environment
+ */
+export const EnvironmentGuard: t.Type<Environment> = t.type({
+  timeInterval: TimeIntervalGuard,
 });

--- a/packages/language/core/v1/src/guards.ts
+++ b/packages/language/core/v1/src/guards.ts
@@ -1,0 +1,96 @@
+/**
+  * This module offers dynamic type guards for the different types of this package.
+  ```
+  import * as G from "@marlowe/language-core-v1/guards"
+  if (G.Contract.is(jsonObject)) {
+    // The jsonObject is a correct Contract
+  } else {
+    // The jsonObject is not a correct Contract
+  }
+  ```
+  @packageDocumentation
+ */
+
+export {
+  ActionGuard as Action,
+  DepositGuard as Deposit,
+  NotifyGuard as Notify,
+  ChoiceGuard as Choice,
+} from "./actions.js";
+
+export {
+  ChoiceNameGuard as ChoiceName,
+  ChoiceIdGuard as ChoiceId,
+  BoundGuard as Bound,
+} from "./choices.js";
+
+export {
+  CloseGuard as Close,
+  PayGuard as Pay,
+  IfGuard as If,
+  LetGuard as Let,
+  AssertGuard as Assert,
+  ContractGuard as Contract,
+  WhenGuard as When,
+  CaseGuard as Case,
+  TimeoutGuard as Timeout,
+} from "./contract.js";
+
+export {
+  EnvironmentGuard as Environment,
+  TimeIntervalGuard as TimeInterval,
+} from "./environment.js";
+
+export {
+  InputGuard as Input,
+  IDepositGuard as IDeposit,
+  IChoiceGuard as IChoice,
+  INotifyGuard as INotify,
+  BuiltinByteStringGuard as BuiltinByteString,
+  InputContentGuard as InputContent,
+  NormalInputGuard as NormalInput,
+  MerkleizedInputGuard as MerkleizedInput,
+} from "./inputs.js";
+
+export {
+  RoleGuard as Role,
+  PartyGuard as Party,
+  AddressGuard as Address,
+} from "./participants.js";
+
+export {
+  PayeeGuard as Payee,
+  PayeeAccountGuard as PayeeAccount,
+  PayeePartyGuard as PayeeParty,
+  AccountIdGuard as AccountId,
+} from "./payee.js";
+
+export { MarloweStateGuard as MarloweState } from "./state.js";
+
+export { TokenGuard as Token, TokenNameGuard as TokenName } from "./token.js";
+
+export {
+  ValueGuard as Value,
+  AvailableMoneyGuard as AvailableMoney,
+  ConstantGuard as Constant,
+  NegValueGuard as NegValue,
+  AddValueGuard as AddValue,
+  SubValueGuard as SubValue,
+  MulValueGuard as MulValue,
+  DivValueGuard as DivValue,
+  ChoiceValueGuard as ChoiceValue,
+  TimeIntervalStartGuard as TimeIntervalStart,
+  TimeIntervalEndGuard as TimeIntervalEnd,
+  UseValueGuard as UseValue,
+  CondGuard as Cond,
+  ObservationGuard as Observation,
+  AndObsGuard as AndObs,
+  OrObsGuard as OrObs,
+  NotObsGuard as NotObs,
+  ChoseSomethingGuard as ChoseSomething,
+  ValueEQGuard as ValueEQ,
+  ValueGTGuard as ValueGT,
+  ValueGEGuard as ValueGE,
+  ValueLTGuard as ValueLT,
+  ValueLEGuard as ValueLE,
+} from "./value-and-observation.js";

--- a/packages/language/core/v1/src/guards.ts
+++ b/packages/language/core/v1/src/guards.ts
@@ -1,11 +1,13 @@
 /**
-  * This module offers dynamic type guards for the different types of this package.
+  * This module offers {@link !io-ts-usage | dynamic type guards} for the for the JSON schema as specified in the Appendix E of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe specification}.
   ```
   import * as G from "@marlowe/language-core-v1/guards"
+  const jsonObject = JSON.parse(fileContents)
+
   if (G.Contract.is(jsonObject)) {
-    // The jsonObject is a correct Contract
+    // The jsonObject respects the JSON schema for Contract
   } else {
-    // The jsonObject is not a correct Contract
+    // The jsonObject does not respect the JSON schema for Contract
   }
   ```
   @packageDocumentation

--- a/packages/language/core/v1/src/guards.ts
+++ b/packages/language/core/v1/src/guards.ts
@@ -67,7 +67,10 @@ export {
   AccountIdGuard as AccountId,
 } from "./payee.js";
 
-export { MarloweStateGuard as MarloweState } from "./state.js";
+export {
+  MarloweStateGuard as MarloweState,
+  AccountsGuard as Accounts,
+} from "./state.js";
 
 export { TokenGuard as Token, TokenNameGuard as TokenName } from "./token.js";
 

--- a/packages/language/core/v1/src/index.ts
+++ b/packages/language/core/v1/src/index.ts
@@ -35,6 +35,7 @@ export {
   Case,
   close,
   datetoTimeout,
+  timeoutToDate,
   Timeout,
 } from "./contract.js";
 export { Environment, mkEnvironment, TimeInterval } from "./environment.js";
@@ -55,7 +56,7 @@ export { role, Party, Address, Role } from "./participants.js";
 
 export { Payee, PayeeAccount, PayeeParty, AccountId } from "./payee.js";
 
-export { Token, TokenName, tokenToString, token } from "./token.js";
+export { Token, TokenName, tokenToString, token, adaToken } from "./token.js";
 
 export { MarloweState } from "./state.js";
 

--- a/packages/language/core/v1/src/index.ts
+++ b/packages/language/core/v1/src/index.ts
@@ -1,34 +1,89 @@
-// TODO: REVISIT
+/**
+ * TODO: comment
+   ```
+  import {Value, Contract} from "@marlowe/language-core-v1"
+  const four: Value = { add: 2n, and: 2n};
+  const contract: Contract = {
+    "when": [
+      {
+        "then": "close",
+        "case": {
+          "party": { "role_token": "Bob" },
+          "of_token": { "token_name": "", "currency_symbol": "" },
+          "into_account": { "role_token": "Alice" },
+          "deposits": 1n
+        }
+      }
+    ],
+    "timeout_continuation": "close",
+    "timeout": 1696345114737n
+  }
+  ```
+ * @packageDocumentation
+ */
 
+export { Action, Deposit, Notify, Choice } from "./actions.js";
+export { ChoiceName, ChoiceId, Bound } from "./choices.js";
 export {
-  Contract,
-  Case,
-  Assert,
   Close,
-  close,
+  Pay,
   If,
   Let,
-  Pay,
+  Assert,
+  Contract,
   When,
+  Case,
+  close,
   datetoTimeout,
-  timeoutToDate,
   Timeout,
 } from "./contract.js";
-export { role, Party } from "./participants.js";
-export { Action } from "./actions.js";
-export { inputNotify } from "./inputs.js";
-export { Input, BuiltinByteString } from "./inputs.js";
-export { Value } from "./value-and-observation.js";
-export { Accounts } from "./state.js";
+export { Environment, mkEnvironment, TimeInterval } from "./environment.js";
+
 export {
-  Token,
-  TokenName,
-  tokenToString,
-  token,
-  adaToken,
-  lovelaceToken,
-} from "./token.js";
+  Input,
+  IDeposit,
+  IChoice,
+  INotify,
+  BuiltinByteString,
+  inputNotify,
+  InputContent,
+  NormalInput,
+  MerkleizedInput,
+} from "./inputs.js";
+
+export { role, Party, Address, Role } from "./participants.js";
+
+export { Payee, PayeeAccount, PayeeParty, AccountId } from "./payee.js";
+
+export { Token, TokenName, tokenToString, token } from "./token.js";
+
+export { MarloweState } from "./state.js";
+
+export {
+  Value,
+  AvailableMoney,
+  Constant,
+  NegValue,
+  AddValue,
+  SubValue,
+  MulValue,
+  DivValue,
+  ChoiceValue,
+  TimeIntervalStart,
+  TimeIntervalEnd,
+  UseValue,
+  Cond,
+  Observation,
+  AndObs,
+  OrObs,
+  NotObs,
+  ChoseSomething,
+  ValueEQ,
+  ValueGT,
+  ValueGE,
+  ValueLT,
+  ValueLE,
+} from "./value-and-observation.js";
+
 export { TokenValue, tokenValue, adaValue } from "./tokenValue.js";
 export { PolicyId } from "./policyId.js";
-export { MarloweState } from "./state.js";
-export { Environment, mkEnvironment } from "./environment.js";

--- a/packages/language/core/v1/src/index.ts
+++ b/packages/language/core/v1/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * TODO: comment
+ *  This module exports static types (only useful in TypeScript) for the JSON schema as specified in the Appendix E of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe specification}
    ```
   import {Value, Contract} from "@marlowe/language-core-v1"
   const four: Value = { add: 2n, and: 2n};

--- a/packages/language/core/v1/src/inputs.ts
+++ b/packages/language/core/v1/src/inputs.ts
@@ -1,49 +1,145 @@
 import * as t from "io-ts/lib/index.js";
-import { Contract } from "./contract.js";
-import { ChoiceId } from "./value-and-observation.js";
-import { Party } from "./participants.js";
-import { AccountId } from "./payee.js";
-import { Token } from "./token.js";
+import { ContractGuard } from "./contract.js";
+import {
+  ChoiceId,
+  ChoiceIdGuard,
+  ChosenNum,
+  ChosenNumGuard,
+} from "./choices.js";
+import { Party, PartyGuard } from "./participants.js";
+import { AccountId, AccountIdGuard } from "./payee.js";
+import { Token, TokenGuard } from "./token.js";
 
-export type ChosenNum = t.TypeOf<typeof ChosenNum>;
-export const ChosenNum = t.bigint;
+/**
+ * TODO: Comment
+ * @see Section 2.1.6 and appendix E.11 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category Input
+ */
+export interface IChoice {
+  for_choice_id: ChoiceId;
+  input_that_chooses_num: ChosenNum;
+}
 
-export type InputChoice = t.TypeOf<typeof InputChoice>;
-export const InputChoice = t.type({
-  for_choice_id: ChoiceId,
-  input_that_chooses_num: ChosenNum,
+/**
+ * TODO: Comment
+ * @see Section 2.1.6 and appendix E.11 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category Input
+ */
+export const IChoiceGuard: t.Type<IChoice> = t.type({
+  for_choice_id: ChoiceIdGuard,
+  input_that_chooses_num: ChosenNumGuard,
 });
 
-export type InputDeposit = t.TypeOf<typeof InputDeposit>;
-export const InputDeposit = t.type({
-  input_from_party: Party,
+/**
+ * TODO: Comment
+ * @see Section 2.1.6 and appendix E.11 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category Input
+ */
+export interface IDeposit {
+  input_from_party: Party;
+  that_deposits: bigint;
+  of_token: Token;
+  into_account: AccountId;
+}
+
+/**
+ * TODO: Comment
+ * @see Section 2.1.6 and appendix E.11 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category Input
+ */
+export const IDepositGuard = t.type({
+  input_from_party: PartyGuard,
   that_deposits: t.bigint,
-  of_token: Token,
-  into_account: AccountId,
+  of_token: TokenGuard,
+  into_account: AccountIdGuard,
 });
 
+/**
+ * Search [[lower-name-builders]]
+ * @hidden
+ */
 export const inputNotify = "input_notify";
-export type InputNotify = t.TypeOf<typeof InputNotify>;
-export const InputNotify = t.literal("input_notify");
+
+/**
+ * TODO: Comment
+ * @see Section 2.1.6 and appendix E.11 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category Input
+ */
+export type INotify = "input_notify";
+
+/**
+ * TODO: Comment
+ * @see Section 2.1.6 and appendix E.11 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category Input
+ */
+export const INotifyGuard: t.Type<INotify> = t.literal("input_notify");
 
 // Maybe this should be a newtype
-export type BuiltinByteString = t.TypeOf<typeof BuiltinByteString>;
-export const BuiltinByteString = t.string;
+/**
+ * TODO: Comment
+ * @category Input
+ */
+export type BuiltinByteString = string;
 
-export type InputContent = t.TypeOf<typeof InputContent>;
-export const InputContent = t.union([InputDeposit, InputChoice, InputNotify]);
+/**
+ * TODO: Comment
+ * @category Input
+ */
+export const BuiltinByteStringGuard: t.Type<BuiltinByteString> = t.string;
+/**
+ * TODO: Comment
+ * @category Input
+ */
+export type InputContent = IDeposit | IChoice | INotify;
+/**
+ * TODO: Comment
+ * @category Input
+ */
+export const InputContentGuard: t.Type<InputContent> = t.union([
+  IDepositGuard,
+  IChoiceGuard,
+  INotifyGuard,
+]);
 
-export type NormalInput = t.TypeOf<typeof NormalInput>;
-export const NormalInput = InputContent;
+/**
+ * TODO: Comment
+ * @category Input
+ */
+export type NormalInput = InputContent;
 
-export type MerkleizedInput = t.TypeOf<typeof MerkleizedInput>;
-export const MerkleizedInput = t.intersection([
-  InputContent,
+/**
+ * TODO: Comment
+ * @category Input
+ */
+export const NormalInputGuard = InputContentGuard;
+
+/**
+ * TODO: Revisit
+ * @category Input
+ */
+export type MerkleizedInput = t.TypeOf<typeof MerkleizedInputGuard>;
+/**
+ * TODO: Revisit
+ * @category Input
+ */
+export const MerkleizedInputGuard = t.intersection([
+  InputContentGuard,
   t.partial({
-    continuation_hash: BuiltinByteString,
-    merkleized_continuation: Contract,
+    continuation_hash: BuiltinByteStringGuard,
+    merkleized_continuation: ContractGuard,
   }),
 ]);
 
-export type Input = t.TypeOf<typeof Input>;
-export const Input = t.union([NormalInput, MerkleizedInput]);
+/**
+ * TODO: Revisit
+ * @category Input
+ */
+export type Input = NormalInput | MerkleizedInput;
+/**
+ * TODO: Revisit
+ * @category Input
+ */
+export const InputGuard: t.Type<Input> = t.union([
+  NormalInputGuard,
+  MerkleizedInputGuard,
+]);

--- a/packages/language/core/v1/src/next/applicables/canChoose.ts
+++ b/packages/language/core/v1/src/next/applicables/canChoose.ts
@@ -1,21 +1,20 @@
 import * as t from "io-ts/lib/index.js";
-import { ChoiceId } from "../../value-and-observation.js";
+import { ChosenNum, ChoiceIdGuard, BoundGuard } from "../../choices.js";
 import { IsMerkleizedContinuation } from "../common/IsMerkleizedContinuation.js";
 import { CaseIndex } from "../common/caseIndex.js";
-import { ChosenNum, InputChoice } from "../../inputs.js";
-import { Bound } from "../../actions.js";
+import { IChoice } from "../../inputs.js";
 
 export type CanChoose = t.TypeOf<typeof CanChoose>;
 export const CanChoose = t.type({
   case_index: CaseIndex,
-  for_choice: ChoiceId,
-  can_choose_between: t.array(Bound),
+  for_choice: ChoiceIdGuard,
+  can_choose_between: t.array(BoundGuard),
   is_merkleized_continuation: IsMerkleizedContinuation,
 });
 
 export const toInput: (
   canChoose: CanChoose
-) => (chosenNum: ChosenNum) => InputChoice = (canChoose) => (chosenNum) => ({
+) => (chosenNum: ChosenNum) => IChoice = (canChoose) => (chosenNum) => ({
   for_choice_id: canChoose.for_choice,
   input_that_chooses_num: chosenNum,
 });

--- a/packages/language/core/v1/src/next/applicables/canDeposit.ts
+++ b/packages/language/core/v1/src/next/applicables/canDeposit.ts
@@ -1,25 +1,23 @@
 import { optionFromNullable } from "io-ts-types";
 import * as t from "io-ts/lib/index.js";
-import { Token } from "../../token.js";
+import { TokenGuard } from "../../token.js";
 import { IsMerkleizedContinuation } from "../common/IsMerkleizedContinuation.js";
 import { CaseIndex } from "../common/caseIndex.js";
-import { InputDeposit } from "../../inputs.js";
-import { Party } from "../../participants.js";
-import { AccountId } from "../../payee.js";
+import { IDeposit, IDepositGuard } from "../../inputs.js";
+import { PartyGuard } from "../../participants.js";
+import { AccountIdGuard } from "../../payee.js";
 
 export type CanDeposit = t.TypeOf<typeof CanDeposit>;
 export const CanDeposit = t.type({
   case_index: CaseIndex,
-  party: Party,
+  party: PartyGuard,
   can_deposit: t.bigint,
-  of_token: Token,
-  into_account: AccountId,
+  of_token: TokenGuard,
+  into_account: AccountIdGuard,
   is_merkleized_continuation: IsMerkleizedContinuation,
 });
 
-export const toInput: (canDeposit: CanDeposit) => InputDeposit = (
-  canDeposit
-) => ({
+export const toInput: (canDeposit: CanDeposit) => IDeposit = (canDeposit) => ({
   input_from_party: canDeposit.party,
   that_deposits: canDeposit.can_deposit,
   of_token: canDeposit.of_token,

--- a/packages/language/core/v1/src/next/applicables/canNotify.ts
+++ b/packages/language/core/v1/src/next/applicables/canNotify.ts
@@ -1,7 +1,7 @@
 import * as t from "io-ts/lib/index.js";
 import { IsMerkleizedContinuation } from "../common/IsMerkleizedContinuation.js";
 import { CaseIndex } from "../common/caseIndex.js";
-import { InputNotify } from "../../inputs.js";
+import { INotify } from "../../inputs.js";
 
 export type CanNotify = t.TypeOf<typeof CanNotify>;
 export const CanNotify = t.type({
@@ -9,5 +9,5 @@ export const CanNotify = t.type({
   is_merkleized_continuation: IsMerkleizedContinuation,
 });
 
-export const toInput: (canNotify: CanNotify) => InputNotify = (canNotify) =>
+export const toInput: (canNotify: CanNotify) => INotify = (canNotify) =>
   "input_notify";

--- a/packages/language/core/v1/src/participants.ts
+++ b/packages/language/core/v1/src/participants.ts
@@ -9,22 +9,67 @@ import * as A from "fp-ts/lib/Array.js";
 
 import { AddressBech32 } from "./address.js";
 
-export type Address = t.TypeOf<typeof Address>;
-export const Address = t.type({ address: AddressBech32 });
+/**
+ * TODO: Comment
+ * @category Party
+ */
+export interface Address {
+  address: AddressBech32;
+}
+/**
+ * TODO: Comment
+ * @category Party
+ */
+export const AddressGuard: t.Type<Address> = t.type({ address: AddressBech32 });
 
-type RoleName = t.TypeOf<typeof RoleName>;
-const RoleName = t.string;
+type RoleName = string;
+const RoleNameGuard: t.Type<RoleName> = t.string;
 
+/**
+ * Search [[lower-name-builders]]
+ * @hidden
+ */
 export const role = (roleToken: RoleName) => ({ role_token: roleToken });
-export type Role = t.TypeOf<typeof Role>;
-export const Role = t.type({ role_token: RoleName });
 
+/**
+ * TODO: Comment
+ * @category Party
+ */
+export interface Role {
+  role_token: RoleName;
+}
+
+/**
+ * TODO: Comment
+ * @category Party
+ */
+export const RoleGuard: t.Type<Role> = t.type({ role_token: RoleNameGuard });
+
+/**
+ * Search [[lower-name-builders]]
+ * @hidden
+ */
 export const party = (party: Role | Address) => party;
-export type Party = t.TypeOf<typeof Party>;
-export const Party = t.union([Address, Role]);
 
+/**
+ * TODO: Comment
+ * @category Party
+ */
+export type Party = Address | Role;
+/**
+ * TODO: Comment
+ * @category Party
+ */
+export const PartyGuard = t.union([AddressGuard, RoleGuard]);
+
+/**
+ * @hidden
+ */
 export const partiesToStrings: (parties: Party[]) => string[] = (parties) =>
   pipe(parties, A.map(partyToString));
 
+/**
+ * @hidden
+ */
 export const partyToString: (party: Party) => string = (party) =>
-  Role.is(party) ? party.role_token : party.address;
+  RoleGuard.is(party) ? party.role_token : party.address;

--- a/packages/language/core/v1/src/payee.ts
+++ b/packages/language/core/v1/src/payee.ts
@@ -1,11 +1,76 @@
 import * as t from "io-ts/lib/index.js";
-import { Party } from "./participants.js";
+import { PartyGuard, Party } from "./participants.js";
 
-export type AccountId = t.TypeOf<typeof Party>;
-export const AccountId = Party;
+/**
+ * TODO: Comment
+ * @category Payee
+ */
+export type AccountId = Party;
 
-export type Payee = t.TypeOf<typeof Payee>;
-export const Payee = t.union([
-  t.type({ account: AccountId }),
-  t.type({ party: Party }),
-]);
+/**
+ * TODO: Comment
+ * @category Payee
+ */
+export const AccountIdGuard = PartyGuard;
+
+// DISCUSSION: [[ payee-name-conflict ]]
+//   The internal types for a Payee are named differently than other types because
+//   there is a name conflict between the Party Constructor and the Party type.
+//   The Party type is defined in the participants module and has Address and Role
+//   as constructors. The Party constructor is defined here in the Payee module.
+//   In Haskell/PureScript this conflict doesn't matter as they live in different
+//   namespaces, but for typescript we need to avoid collision, so I've added a Payee
+//   prefix.
+//   Eventually it would be ideal to rename Account to Internal and Party to External
+//   to better indicate the intent of a Payout. But this should be done as a single effort
+//   all acrross the codebase.
+
+/**
+ * TODO: Comment
+ * @category Payee
+ */
+// see [[ payee-name-conflict ]]
+export interface PayeeAccount {
+  account: AccountId;
+}
+
+/**
+ * TODO: Comment
+ * @category Payee
+ */
+// see [[ payee-name-conflict ]]
+export const PayeeAccountGuard = t.type({
+  account: AccountIdGuard,
+});
+
+/**
+ * TODO: Comment
+ * @category Payee
+ */
+// see [[ payee-name-conflict ]]
+export interface PayeeParty {
+  party: Party;
+}
+
+/**
+ * TODO: Comment
+ * @category Payee
+ */
+// see [[ payee-name-conflict ]]
+export const PayeePartyGuard = t.type({
+  party: PartyGuard,
+});
+
+/**
+ * TODO: Comment
+ * @category Payee
+ */
+// see [[ payee-name-conflict ]]
+export type Payee = PayeeAccount | PayeeParty;
+
+/**
+ * TODO: Comment
+ * @category Payee
+ */
+// see [[ payee-name-conflict ]]
+export const PayeeGuard = t.union([PayeeAccountGuard, PayeePartyGuard]);

--- a/packages/language/core/v1/src/policyId.ts
+++ b/packages/language/core/v1/src/policyId.ts
@@ -1,5 +1,11 @@
 import * as t from "io-ts/lib/index.js";
 
 // TODO: We should delete this one as there is already a newtype in runtime-core
+/**
+ * @category Token
+ */
 export type PolicyId = string;
+/**
+ * @category Token
+ */
 export const PolicyId = t.string;

--- a/packages/language/core/v1/src/state.ts
+++ b/packages/language/core/v1/src/state.ts
@@ -1,20 +1,58 @@
 import * as t from "io-ts/lib/index.js";
-import { AccountId } from "./payee.js";
+import { AccountIdGuard } from "./payee.js";
 
-import { ChoiceId, ValueId } from "./value-and-observation.js";
-import { Token } from "./token.js";
+import { ValueId, ValueIdGuard } from "./value-and-observation.js";
+import { TokenGuard } from "./token.js";
+import { ChoiceId, ChoiceIdGuard } from "./choices.js";
 
 export type Account = t.TypeOf<typeof Account>;
-export const Account = t.tuple([t.tuple([AccountId, Token]), t.bigint]);
+export const Account = t.tuple([
+  t.tuple([AccountIdGuard, TokenGuard]),
+  t.bigint,
+]);
 
-export type Accounts = t.TypeOf<typeof Accounts>;
-export const Accounts = t.array(Account);
+/**
+ * TODO: Comment
+ * @category State
+ */
+export type Accounts = t.TypeOf<typeof AccountsGuard>;
+// DISCUSSION: Instead of having a custom guard for this we could have
+//             an associative Map guard.
+/**
+ * TODO: Comment
+ * @category State
+ */
+export const AccountsGuard = t.array(Account);
 
-export type MarloweState = t.TypeOf<typeof MarloweState>;
-
-export const MarloweState = t.type({
-  accounts: Accounts,
-  boundValues: t.array(t.tuple([ValueId, t.bigint])),
-  choices: t.array(t.tuple([ChoiceId, t.bigint])),
+// DISCUSSION: Should we have the serialization representation here (associative map)
+//             or to have a real JS Map? All the other types are in serialization representation.
+/**
+ * TODO: Comment
+ * @see Section 2.1.8 and appendix E.14 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category State
+ */
+export interface MarloweState {
+  accounts: Accounts;
+  /**
+   * TODO: Comment
+   * Serialized as associative map
+   */
+  boundValues: Array<[ValueId, bigint]>;
+  /**
+   * TODO: Comment
+   * Serialized as associative map
+   */
+  choices: Array<[ChoiceId, bigint]>;
+  minTime: bigint;
+}
+/**
+ * TODO: Comment
+ * @see Section 2.1.8 and appendix E.14 of the {@link https://github.com/input-output-hk/marlowe/releases/download/v3/Marlowe.pdf | Marlowe spec}
+ * @category State
+ */
+export const MarloweStateGuard: t.Type<MarloweState> = t.type({
+  accounts: AccountsGuard,
+  boundValues: t.array(t.tuple([ValueIdGuard, t.bigint])),
+  choices: t.array(t.tuple([ChoiceIdGuard, t.bigint])),
   minTime: t.bigint,
 });

--- a/packages/language/core/v1/src/token.ts
+++ b/packages/language/core/v1/src/token.ts
@@ -1,22 +1,63 @@
 import * as t from "io-ts/lib/index.js";
 import { PolicyId } from "./policyId.js";
+/**
+ * TODO: Comment
+ * @category Token
+ */
+export type TokenName = string;
+/**
+ * TODO: Comment
+ * @category Token
+ */
+export const TokenNameGuard: t.Type<string> = t.string;
 
-export type TokenName = t.TypeOf<typeof TokenName>;
-export const TokenName = t.string;
+/**
+ * TODO: Comment
+ * @category Token
+ */
+export interface Token {
+  /**
+   * TODO: Comment
+   */
+  currency_symbol: PolicyId;
+  /**
+   * TODO: Comment
+   */
 
-export type Token = t.TypeOf<typeof Token>;
-export const Token = t.type({
+  token_name: TokenName;
+}
+/**
+ * TODO: Comment
+ * @category Token
+ */
+export const TokenGuard: t.Type<Token> = t.type({
   currency_symbol: PolicyId,
-  token_name: TokenName,
+  token_name: TokenNameGuard,
 });
 
+/**
+ * Search [[lower-name-builders]]
+ * @hidden
+ */
 export const token = (currency_symbol: PolicyId, token_name: TokenName) => ({
   currency_symbol: currency_symbol,
   token_name: token_name,
 });
 
+/**
+ * @hidden
+ */
 export const tokenToString: (token: Token) => string = (token) =>
   `${token.currency_symbol}|${token.token_name}`;
 
+/**
+ * @hidden
+ */
 export const lovelaceToken: Token = token("", "");
+/**
+ * DISCUSSION: In different places (like the playground)
+ * we use the name `ada` for the lovelace token, I think we
+ * should only use lovelace as it can be missleading.
+ * @hidden
+ */
 export const adaToken: Token = lovelaceToken;

--- a/packages/language/core/v1/src/tokenValue.ts
+++ b/packages/language/core/v1/src/tokenValue.ts
@@ -1,18 +1,42 @@
 import * as t from "io-ts/lib/index.js";
 import * as T from "./token.js";
 
+/**
+ * search [[token-vs-token_value]]
+ * @hidden
+ */
 export const toString: (token: TokenValue) => string = (tokenValue) =>
   `${tokenValue.amount} - ${T.tokenToString(tokenValue.token)}`;
 
+/**
+ * search [[token-vs-token_value]]
+ * @hidden
+ */
 export type TokenValue = t.TypeOf<typeof TokenValue>;
-export const TokenValue = t.type({ amount: t.bigint, token: T.Token });
+/**
+ * search [[token-vs-token_value]]
+ * @hidden
+ */
+export const TokenValue = t.type({ amount: t.bigint, token: T.TokenGuard });
+/**
+ * search [[token-vs-token_value]]
+ * @hidden
+ */
 export const tokenValue: (amount: bigint) => (token: T.Token) => TokenValue =
   (amount) => (token) => ({ amount: amount, token: token });
 
+/**
+ * search [[token-vs-token_value]]
+ * @hidden
+ */
 export const lovelaceValue: (lovelaces: bigint) => TokenValue = (
   lovelaces
 ) => ({ amount: lovelaces, token: T.adaToken });
 
+/**
+ * search [[token-vs-token_value]]
+ * @hidden
+ */
 export const adaValue: (adaAmount: bigint) => TokenValue = (adaAmount) => ({
   amount: adaAmount * 1_000_000n,
   token: T.adaToken,

--- a/packages/language/core/v1/src/value-and-observation.ts
+++ b/packages/language/core/v1/src/value-and-observation.ts
@@ -4,79 +4,215 @@
  * @packageDocumentation
  */
 import * as t from "io-ts/lib/index.js";
-import { Party } from "./participants.js";
+import { ChoiceId, ChoiceIdGuard } from "./choices.js";
+import { AccountId, AccountIdGuard } from "./payee.js";
+import { Token, TokenGuard } from "./token.js";
 
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export interface AvailableMoney {
+  amount_of_token: Token;
+  in_account: AccountId;
+}
+
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const AvailableMoneyGuard: t.Type<AvailableMoney> = t.type({
+  amount_of_token: TokenGuard,
+  in_account: AccountIdGuard,
+});
+
+/**
+ * Search [[lower-name-builders]]
+ * @hidden
+ */
 export const constant = (constant: bigint) => constant;
-export type Constant = t.TypeOf<typeof Constant>;
-export const Constant = t.bigint;
 
-export type TimeIntervalStart = t.TypeOf<typeof TimeIntervalStart>;
-export const TimeIntervalStart = t.literal("time_interval_start");
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export type Constant = bigint;
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const ConstantGuard: t.Type<Constant> = t.bigint;
 
-export type TimeIntervalEnd = t.TypeOf<typeof TimeIntervalEnd>;
-export const TimeIntervalEnd = t.literal("time_interval_end");
-
-export type NegValue = { negate: Value };
-export const NegValue: t.Type<NegValue> = t.recursion("NegValue", () =>
-  t.type({ negate: Value })
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export type TimeIntervalStart = "time_interval_start";
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const TimeIntervalStartGuard: t.Type<TimeIntervalStart> = t.literal(
+  "time_interval_start"
 );
 
-export type AddValue = { add: Value; and: Value };
-
-export const AddValue: t.Type<AddValue> = t.recursion("AddValue", () =>
-  t.type({ add: Value, and: Value })
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export type TimeIntervalEnd = "time_interval_end";
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const TimeIntervalEndGuard = t.literal("time_interval_end");
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export interface NegValue {
+  negate: Value;
+}
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const NegValueGuard: t.Type<NegValue> = t.recursion("NegValue", () =>
+  t.type({ negate: ValueGuard })
 );
 
-export type SubValue = { value: Value; minus: Value };
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export interface AddValue {
+  add: Value;
+  and: Value;
+}
 
-export const SubValue: t.Type<SubValue> = t.recursion("SubValue", () =>
-  t.type({ value: Value, minus: Value })
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const AddValueGuard: t.Type<AddValue> = t.recursion("AddValue", () =>
+  t.type({ add: ValueGuard, and: ValueGuard })
 );
 
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export interface SubValue {
+  value: Value;
+  minus: Value;
+}
+
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const SubValueGuard: t.Type<SubValue> = t.recursion("SubValue", () =>
+  t.type({ value: ValueGuard, minus: ValueGuard })
+);
+
+/**
+ * Search [[lower-name-builders]]
+ * @hidden
+ */
 export const mulValue = (multiply: Value, times: Value) => ({
   multiply: multiply,
   times: times,
 });
-export type MulValue = { multiply: Value; times: Value };
 
-export const MulValue: t.Type<MulValue> = t.recursion("MulValue", () =>
-  t.type({ multiply: Value, times: Value })
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export interface MulValue {
+  multiply: Value;
+  times: Value;
+}
+
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const MulValueGuard: t.Type<MulValue> = t.recursion("MulValue", () =>
+  t.type({ multiply: ValueGuard, times: ValueGuard })
 );
 
-export type DivValue = { divide: Value; by: Value };
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export interface DivValue {
+  divide: Value;
+  by: Value;
+}
 
-export const DivValue: t.Type<DivValue> = t.recursion("DivValue", () =>
-  t.type({ divide: Value, by: Value })
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const DivValueGuard: t.Type<DivValue> = t.recursion("DivValue", () =>
+  t.type({ divide: ValueGuard, by: ValueGuard })
 );
 
-export type ChoiceName = t.TypeOf<typeof ChoiceName>;
-export const ChoiceName = t.string;
-
-export type ChoiceId = t.TypeOf<typeof ChoiceId>;
-export const ChoiceId = t.type({
-  choice_name: ChoiceName,
-  choice_owner: Party,
-});
-
+/**
+ * TODO: Comment
+ * @category Value
+ */
 export type ChoiceValue = { value_of_choice: ChoiceId };
-export const ChoiceValue: t.Type<ChoiceValue> = t.recursion("ChoiceValue", () =>
-  t.type({ value_of_choice: ChoiceId })
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const ChoiceValueGuard: t.Type<ChoiceValue> = t.recursion(
+  "ChoiceValue",
+  () => t.type({ value_of_choice: ChoiceIdGuard })
 );
 
-export type ValueId = t.TypeOf<typeof ValueId>;
-export const ValueId = t.string;
-
-export type UseValue = { use_value: ValueId };
-export const UseValue: t.Type<UseValue> = t.recursion("UseValue", () =>
-  t.type({ use_value: ValueId })
+export type ValueId = string;
+export const ValueIdGuard: t.Type<ValueId> = t.string;
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export interface UseValue {
+  use_value: ValueId;
+}
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const UseValueGuard: t.Type<UseValue> = t.recursion("UseValue", () =>
+  t.type({ use_value: ValueIdGuard })
 );
 
-export type Cond = { if: Observation; then: Value; else: Value };
-export const Cond: t.Type<Cond> = t.recursion("Cond", () =>
-  t.type({ if: Observation, then: Value, else: Value })
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export interface Cond {
+  if: Observation;
+  then: Value;
+  else: Value;
+}
+
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const CondGuard: t.Type<Cond> = t.recursion("Cond", () =>
+  t.type({ if: ObservationGuard, then: ValueGuard, else: ValueGuard })
 );
 
+/**
+ * TODO: Comment
+ * @category Value
+ */
 export type Value =
+  | AvailableMoney
   | Constant
   | NegValue
   | AddValue
@@ -89,97 +225,210 @@ export type Value =
   | UseValue
   | Cond;
 
-export const Value: t.Type<Value> = t.recursion("Value", () =>
+/**
+ * TODO: Comment
+ * @category Value
+ */
+export const ValueGuard: t.Type<Value> = t.recursion("Value", () =>
   t.union([
-    Constant,
-    NegValue,
-    AddValue,
-    SubValue,
-    MulValue,
-    DivValue,
-    ChoiceValue,
-    TimeIntervalStart,
-    TimeIntervalEnd,
-    UseValue,
-    Cond,
+    AvailableMoneyGuard,
+    ConstantGuard,
+    NegValueGuard,
+    AddValueGuard,
+    SubValueGuard,
+    MulValueGuard,
+    DivValueGuard,
+    ChoiceValueGuard,
+    TimeIntervalStartGuard,
+    TimeIntervalEndGuard,
+    UseValueGuard,
+    CondGuard,
   ])
 );
 
-export type And = { both: Observation; and: Observation };
-export const And: t.Type<And> = t.recursion("And", () =>
-  t.type({ both: Observation, and: Observation })
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export interface AndObs {
+  both: Observation;
+  and: Observation;
+}
+
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export const AndObsGuard: t.Type<AndObs> = t.recursion("AndObs", () =>
+  t.type({ both: ObservationGuard, and: ObservationGuard })
 );
 
-export type Or = { either: Observation; or: Observation };
-export const Or: t.Type<Or> = t.recursion("Or", () =>
-  t.type({ either: Observation, or: Observation })
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export interface OrObs {
+  either: Observation;
+  or: Observation;
+}
+
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export const OrObsGuard: t.Type<OrObs> = t.recursion("OrObs", () =>
+  t.type({ either: ObservationGuard, or: ObservationGuard })
 );
 
-export type Not = { not: Observation };
-export const Not: t.Type<Not> = t.recursion("Not", () =>
-  t.type({ not: Observation })
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export interface NotObs {
+  not: Observation;
+}
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export const NotObsGuard: t.Type<NotObs> = t.recursion("NotObs", () =>
+  t.type({ not: ObservationGuard })
 );
 
-export type Chose = { chose_something_for: ChoiceId };
-export const Chose: t.Type<Chose> = t.recursion("Chose", () =>
-  t.type({ chose_something_for: ChoiceId })
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export interface ChoseSomething {
+  chose_something_for: ChoiceId;
+}
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+// TODO: try to remove recursion
+export const ChoseSomethingGuard: t.Type<ChoseSomething> = t.recursion(
+  "ChoseSomething",
+  () => t.type({ chose_something_for: ChoiceIdGuard })
 );
 
-export type Equal = { value: Value; equal_to: Value };
-
-export const Equal: t.Type<Equal> = t.recursion("Equal", () =>
-  t.type({ value: Value, equal_to: Value })
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export interface ValueEQ {
+  value: Value;
+  equal_to: Value;
+}
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export const ValueEQGuard: t.Type<ValueEQ> = t.recursion("ValueEQ", () =>
+  t.type({ value: ValueGuard, equal_to: ValueGuard })
 );
 
-export type Greater = { value: Value; gt: Value };
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export interface ValueGT {
+  value: Value;
+  gt: Value;
+}
 
-export const Greater: t.Type<Greater> = t.recursion("Greater", () =>
-  t.type({ value: Value, gt: Value })
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export const ValueGTGuard: t.Type<ValueGT> = t.recursion("ValueGT", () =>
+  t.type({ value: ValueGuard, gt: ValueGuard })
 );
 
-export type GreaterOrEqual = { value: Value; ge_than: Value };
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export interface ValueGE {
+  value: Value;
+  ge_than: Value;
+}
 
-export const GreaterOrEqual: t.Type<GreaterOrEqual> = t.recursion(
-  "GreaterOrEqual",
-  () => t.type({ value: Value, ge_than: Value })
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export const ValueGEGuard: t.Type<ValueGE> = t.recursion("ValueGE", () =>
+  t.type({ value: ValueGuard, ge_than: ValueGuard })
 );
 
-export type Lower = { value: Value; lt: Value };
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export interface ValueLT {
+  value: Value;
+  lt: Value;
+}
 
-export const Lower: t.Type<Lower> = t.recursion("Lower", () =>
-  t.type({ value: Value, lt: Value })
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export const ValueLTGuard: t.Type<ValueLT> = t.recursion("ValueLT", () =>
+  t.type({ value: ValueGuard, lt: ValueGuard })
 );
 
-export type LowerOrEqual = { value: Value; le_than: Value };
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export interface ValueLE {
+  value: Value;
+  le_than: Value;
+}
 
-export const LowerOrEqual: t.Type<LowerOrEqual> = t.recursion(
-  "LowerOrEqual",
-  () => t.type({ value: Value, le_than: Value })
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export const ValueLEGuard: t.Type<ValueLE> = t.recursion("ValueLE", () =>
+  t.type({ value: ValueGuard, le_than: ValueGuard })
 );
 
+/**
+ * TODO: Comment
+ * @category Observation
+ */
 export type Observation =
-  | And
-  | Or
-  | Not
-  | Chose
-  | Equal
-  | Greater
-  | GreaterOrEqual
-  | Lower
-  | LowerOrEqual
+  | AndObs
+  | OrObs
+  | NotObs
+  | ChoseSomething
+  | ValueEQ
+  | ValueGT
+  | ValueGE
+  | ValueLT
+  | ValueLE
   | boolean;
 
-export const Observation: t.Type<Observation> = t.recursion("Observation", () =>
-  t.union([
-    And,
-    Or,
-    Not,
-    Chose,
-    Equal,
-    Greater,
-    GreaterOrEqual,
-    Lower,
-    LowerOrEqual,
-    t.boolean,
-  ])
+/**
+ * TODO: Comment
+ * @category Observation
+ */
+export const ObservationGuard: t.Type<Observation> = t.recursion(
+  "Observation",
+  () =>
+    t.union([
+      AndObsGuard,
+      OrObsGuard,
+      NotObsGuard,
+      ChoseSomethingGuard,
+      ValueEQGuard,
+      ValueGTGuard,
+      ValueGEGuard,
+      ValueLTGuard,
+      ValueLEGuard,
+      t.boolean,
+    ])
 );

--- a/packages/language/core/v1/test/examples/parsing.spec.ts
+++ b/packages/language/core/v1/test/examples/parsing.spec.ts
@@ -4,7 +4,7 @@ import * as E from "fp-ts/lib/Either.js";
 import "@relmify/jest-fp-ts";
 import { pipe } from "fp-ts/lib/function.js";
 import { formatValidationErrors } from "jsonbigint-io-ts-reporters";
-import { Contract } from "@marlowe.io/language-core-v1";
+import { Contract } from "@marlowe.io/language-core-v1/guards";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { MarloweJSONCodec, minify } from "@marlowe.io/adapter/codec";

--- a/packages/language/core/v1/test/semantics/contract/common/payee/accounts/parsing.spec.ts
+++ b/packages/language/core/v1/test/semantics/contract/common/payee/accounts/parsing.spec.ts
@@ -6,7 +6,7 @@ import { formatValidationErrors } from "jsonbigint-io-ts-reporters";
 import * as path from "path";
 import { MarloweJSONCodec, minify } from "@marlowe.io/adapter/codec";
 import { fileURLToPath } from "url";
-import { Accounts } from "@marlowe.io/language-core-v1";
+import { Accounts } from "@marlowe.io/language-core-v1/guards";
 import { getFileContents } from "@marlowe.io/adapter/file";
 
 const getfilename = () => fileURLToPath(import.meta.url);

--- a/packages/language/core/v1/test/semantics/contract/common/value/parsing.spec.ts
+++ b/packages/language/core/v1/test/semantics/contract/common/value/parsing.spec.ts
@@ -3,7 +3,7 @@ import * as E from "fp-ts/lib/Either.js";
 
 import { pipe } from "fp-ts/lib/function.js";
 import { formatValidationErrors } from "jsonbigint-io-ts-reporters";
-import { Value } from "@marlowe.io/language-core-v1";
+import { Value } from "@marlowe.io/language-core-v1/guards";
 import * as path from "path";
 import { MarloweJSONCodec, minify } from "@marlowe.io/adapter/codec";
 import { fileURLToPath } from "url";

--- a/packages/language/core/v1/test/semantics/contract/parsing.spec.ts
+++ b/packages/language/core/v1/test/semantics/contract/parsing.spec.ts
@@ -4,7 +4,7 @@ import * as E from "fp-ts/lib/Either.js";
 import "@relmify/jest-fp-ts";
 import { pipe } from "fp-ts/lib/function.js";
 import { formatValidationErrors } from "jsonbigint-io-ts-reporters";
-import { Contract } from "@marlowe.io/language-core-v1";
+import { Contract } from "@marlowe.io/language-core-v1/guards";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { MarloweJSONCodec, minify } from "@marlowe.io/adapter/codec";

--- a/packages/language/core/v1/test/semantics/contract/when/action/parsing.spec.ts
+++ b/packages/language/core/v1/test/semantics/contract/when/action/parsing.spec.ts
@@ -4,7 +4,7 @@ import * as E from "fp-ts/lib/Either.js";
 import "@relmify/jest-fp-ts";
 import { pipe } from "fp-ts/lib/function.js";
 import { formatValidationErrors } from "jsonbigint-io-ts-reporters";
-import { Action } from "@marlowe.io/language-core-v1";
+import { Action } from "@marlowe.io/language-core-v1/guards";
 import * as path from "path";
 import { MarloweJSONCodec, minify } from "@marlowe.io/adapter/codec";
 import { getFileContents } from "@marlowe.io/adapter/file";

--- a/packages/language/core/v1/typedoc.json
+++ b/packages/language/core/v1/typedoc.json
@@ -1,5 +1,18 @@
 {
   "entryPointStrategy": "expand",
-  "entryPoints": ["./src"],
-  "tsconfig": "./src/tsconfig.json"
+  "entryPoints": ["./src/index.ts", "./src/next/index.ts", "./src/guards.ts"],
+  "tsconfig": "./src/tsconfig.json",
+  "categorizeByGroup": false,
+  "defaultCategory": "General",
+  "categoryOrder": [
+    "Contract",
+    "Observation",
+    "Action",
+    "Value",
+    "Payee",
+    "Party",
+    "Token",
+    "Choice",
+    "*"
+  ]
 }

--- a/packages/runtime/client/rest/src/contract/details.ts
+++ b/packages/runtime/client/rest/src/contract/details.ts
@@ -1,6 +1,7 @@
 import { optionFromNullable } from "io-ts-types";
 import * as t from "io-ts/lib/index.js";
 import { Contract, MarloweState } from "@marlowe.io/language-core-v1";
+import * as G from "@marlowe.io/language-core-v1/guards";
 import { MarloweVersion } from "@marlowe.io/language-core-v1/version";
 import { ContractId } from "@marlowe.io/runtime-core";
 
@@ -56,9 +57,9 @@ export const ContractDetails = t.type({
   status: TxStatus,
   block: optionFromNullable(BlockHeader),
   metadata: Metadata,
-  initialContract: Contract,
-  currentContract: optionFromNullable(Contract), // 3 actions
-  state: optionFromNullable(MarloweState),
+  initialContract: G.Contract,
+  currentContract: optionFromNullable(G.Contract), // 3 actions
+  state: optionFromNullable(G.MarloweState),
   txBody: optionFromNullable(TextEnvelope),
   utxo: optionFromNullable(TxOutRef),
   unclaimedPayouts: t.array(Payout),

--- a/packages/runtime/client/rest/src/contract/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/contract/endpoints/collection.ts
@@ -12,6 +12,7 @@ import { fromNewtype, optionFromNullable } from "io-ts-types";
 import { stringify } from "qs";
 
 import { Contract } from "@marlowe.io/language-core-v1";
+import * as G from "@marlowe.io/language-core-v1/guards";
 import { MarloweVersion } from "@marlowe.io/language-core-v1/version";
 
 import * as HTTP from "@marlowe.io/adapter/http";
@@ -235,7 +236,7 @@ export type PostContractsRequest = t.TypeOf<typeof PostContractsRequest>;
  */
 export const PostContractsRequest = t.intersection([
   t.type({
-    contract: Contract,
+    contract: G.Contract,
     version: MarloweVersion,
     tags: Tags,
     metadata: Metadata,

--- a/packages/runtime/client/rest/src/contract/next/endpoint.ts
+++ b/packages/runtime/client/rest/src/contract/next/endpoint.ts
@@ -9,6 +9,7 @@ import { Environment, Party } from "@marlowe.io/language-core-v1";
 import { Next } from "@marlowe.io/language-core-v1/next";
 import { stringify } from "qs";
 import { DecodingError } from "@marlowe.io/adapter/codec";
+import { posixTimeToIso8601 } from "@marlowe.io/adapter/time";
 
 export type GET = (
   contractId: ContractId
@@ -21,7 +22,9 @@ export const getViaAxios: (axiosInstance: AxiosInstance) => GET =
     pipe(
       HTTP.Get(axiosInstance)(
         contractNextEndpoint(contractId) +
-          `?validityStart=${environment.validityStart}&validityEnd=${environment.validityEnd}&` +
+          `?validityStart=${posixTimeToIso8601(
+            environment.timeInterval.from
+          )}&validityEnd=${posixTimeToIso8601(environment.timeInterval.to)}&` +
           stringify({ party: parties }, { indices: false }),
         {
           headers: {

--- a/packages/runtime/client/rest/src/contract/transaction/details.ts
+++ b/packages/runtime/client/rest/src/contract/transaction/details.ts
@@ -9,7 +9,7 @@ import {
   MarloweState,
   Contract,
 } from "@marlowe.io/language-core-v1";
-
+import * as G from "@marlowe.io/language-core-v1/guards";
 import {
   Tags,
   Metadata,
@@ -26,16 +26,16 @@ export type Details = t.TypeOf<typeof Details>;
 export const Details = t.type({
   contractId: ContractId,
   transactionId: TxId,
-  continuations: optionFromNullable(BuiltinByteString),
+  continuations: optionFromNullable(G.BuiltinByteString),
   tags: Tags,
   metadata: Metadata,
   status: TxStatus,
   block: optionFromNullable(BlockHeader),
   inputUtxo: TxOutRef,
-  inputs: t.array(Input),
+  inputs: t.array(G.Input),
   outputUtxo: optionFromNullable(TxOutRef),
-  outputContract: optionFromNullable(Contract),
-  outputState: optionFromNullable(MarloweState),
+  outputContract: optionFromNullable(G.Contract),
+  outputState: optionFromNullable(G.MarloweState),
   consumingTx: optionFromNullable(TxId),
   invalidBefore: ISO8601,
   invalidHereafter: ISO8601,

--- a/packages/runtime/client/rest/src/contract/transaction/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/contract/transaction/endpoints/collection.ts
@@ -9,7 +9,7 @@ import { formatValidationErrors } from "jsonbigint-io-ts-reporters";
 import { fromNewtype, optionFromNullable } from "io-ts-types";
 import { AxiosInstance } from "axios";
 
-import { Input } from "@marlowe.io/language-core-v1";
+import * as G from "@marlowe.io/language-core-v1/guards";
 import { MarloweVersion } from "@marlowe.io/language-core-v1/version";
 
 import * as HTTP from "@marlowe.io/adapter/http";
@@ -143,7 +143,7 @@ export type PostTransactionsRequest = t.TypeOf<typeof PostTransactionsRequest>;
 export const PostTransactionsRequest = t.intersection([
   t.type({
     version: MarloweVersion,
-    inputs: t.array(Input),
+    inputs: t.array(G.Input),
     metadata: Metadata,
     tags: Tags,
   }),

--- a/packages/runtime/client/rest/src/contract/transaction/header.ts
+++ b/packages/runtime/client/rest/src/contract/transaction/header.ts
@@ -1,7 +1,7 @@
 import * as t from "io-ts/lib/index.js";
 import { optionFromNullable } from "io-ts-types";
 
-import { BuiltinByteString } from "@marlowe.io/language-core-v1";
+import * as G from "@marlowe.io/language-core-v1/guards";
 import {
   Tags,
   Metadata,
@@ -32,7 +32,7 @@ export const TxHeader = t.type({
    */
   contractId: ContractId,
   transactionId: TxId,
-  continuations: optionFromNullable(BuiltinByteString),
+  continuations: optionFromNullable(G.BuiltinByteString),
   tags: Tags,
   metadata: Metadata,
   status: TxStatus,

--- a/packages/runtime/core/Readme.md
+++ b/packages/runtime/core/Readme.md
@@ -1,5 +1,3 @@
 # @marlowe.io/runtime-core
 
 A Set of core functionalities that supports @marlowe.io libraries
-
-DISCUSSION: What is the difference between this package and the adaptor package? They both seem like utilities packages.

--- a/packages/wallet/src/api.ts
+++ b/packages/wallet/src/api.ts
@@ -81,14 +81,16 @@ export interface WalletAPI {
    */
   isMainnet(): Promise<boolean>;
   // DISCUSSION: should we rename this function to getAssets?
-  // DISCUSSION: Being this a Marlowe Wallet API, should we return a Marlowe Asset (Marlowe Token + Quantity) instead of
-  //             CIP30 Token?
+  // DISCUSSION: [[token-vs-token_value]] We have the same term (Token) overloaded. In the language-core-v1 package
+  //             Token refers to the policy id and token name, in the runtime-core it refers to that plus quantity.
+  //             In the language-core-v1 we have TokenValue (which doesn't exist in the ecosystem) which is iso to the runtime-core Token.
+  //             We should unify the names and avoid term overload.
   /**
    * Get the tokens available to the wallet.
    * @experimental
    *
    * @remarks
-   * The {@link @marlowe.io/runtime-core!asset.Token} type here refers to the `runtime-core` type and not the `language-core-v1` {@link @marlowe.io/language-core-v1!token.Token}.
+   * The {@link @marlowe.io/runtime-core!asset.Token} type here refers to the `runtime-core` type and not the `language-core-v1` {@link @marlowe.io/language-core-v1!index.Token}.
    */
   getTokens(): Promise<Token[]>;
   // DISCUSSION: Should we make this a separate function similar to `getAddressesAndCollaterals`?

--- a/pocs/contract-example/vesting-flow.html
+++ b/pocs/contract-example/vesting-flow.html
@@ -56,7 +56,7 @@
     </div>
   </body>
   <script type="module">
-    import { clearConsole, log, getRuntimeUrl } from "../js/poc-helpers.js";
+    import { clearConsole, log, getRuntimeUrl, setupLocalStorageRuntimeUrl } from "../js/poc-helpers.js";
     import { mkRuntimeLifecycle } from "@marlowe.io/runtime-lifecycle/browser";
     import { Vesting } from "@marlowe.io/language-examples";
     import { MarloweJSON } from "@marlowe.io/adapter/codec";
@@ -255,5 +255,6 @@
     document
       .getElementById("apply-input")
       .addEventListener("click", applyInput);
+    setupLocalStorageRuntimeUrl();
   </script>
 </html>


### PR DESCRIPTION
This PR modifies the export mechanism of `language-core-v1` and separates them into three modules.

To test this PR download the correct branch and make sure the Doc structure make sense. Also, search for `DISCUSSION` comments.

<img width="1416" alt="Screenshot 2023-10-03 at 14 47 51" src="https://github.com/input-output-hk/marlowe-ts-sdk/assets/2634059/b14e97d5-41fa-41fe-b3ee-6378163d90b2">


