### PR TITLE
PLT-7696: Create flat version of createWithdrawal

### DIFF
--- a/packages/runtime/client/rest/src/index.ts
+++ b/packages/runtime/client/rest/src/index.ts
@@ -252,8 +252,14 @@ export function mkRestClient(baseURL: string): RestAPI {
         Transaction.getViaAxios(axiosInstance)(contractId, txId)
       );
     },
-    withdrawPayouts({}) {
-      return Promise.reject();
+    withdrawPayouts({ payoutIds, changeAddress, ...request }) {
+      return unsafeTaskEither(
+        Withdrawals.postViaAxios(axiosInstance)(payoutIds, {
+          changeAddress,
+          usedAddresses: request.usedAddresses ?? [],
+          collateralUTxOs: request.collateralUTxOs ?? [],
+        })
+      );
     },
     healthcheck: () =>
       pipe(

--- a/packages/runtime/client/rest/src/index.ts
+++ b/packages/runtime/client/rest/src/index.ts
@@ -144,7 +144,13 @@ export interface RestAPI {
   //   submitTransaction: Transaction.PUT; // - Jamie is it this one? https://docs.marlowe.iohk.io/api/create-transaction-by-id? If so, lets unify
 
   //   getWithdrawals: Withdrawals.GET; // - https://docs.marlowe.iohk.io/api/get-withdrawals
-  //   createWithdrawal: Withdrawals.POST; // - https://docs.marlowe.iohk.io/api/create-withdrawals
+  /**
+   * Build an unsigned transaction (sign with the {@link @marlowe.io/wallet!api.WalletAPI#signTx} procedure) which withdraws available payouts from a contract (when applied with the {@link @marlowe.io/runtime/client/rest!index.RestAPI.html#submitWithdrawal} procedure).
+   * @see {@link https://docs.marlowe.iohk.io/api/withdraw-payouts}
+   */
+  withdrawPayouts(
+    request: Withdrawals.WithdrawPayoutsRequest
+  ): Promise<Withdrawals.WithdrawPayoutsResponse>;
   //   getWithdrawalById: Withdrawal.GET; // - https://docs.marlowe.iohk.io/api/get-withdrawal-by-id
   //   submitWithdrawal: Withdrawal.PUT; - is it this one? https://docs.marlowe.iohk.io/api/create-withdrawal? or the one for createWithdrawal?
   // TODO: PLT-7719 we should also export the return headers information (Node-Tip Runtime-Chain-Tip Runtime-Tip Runtime-Version Network-Id)
@@ -245,6 +251,9 @@ export function mkRestClient(baseURL: string): RestAPI {
       return unsafeTaskEither(
         Transaction.getViaAxios(axiosInstance)(contractId, txId)
       );
+    },
+    withdrawPayouts({}) {
+      return Promise.reject();
     },
     healthcheck: () =>
       pipe(

--- a/packages/runtime/client/rest/src/withdrawal/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/withdrawal/endpoints/collection.ts
@@ -16,9 +16,11 @@ import * as HTTP from "@marlowe.io/adapter/http";
 import { DecodingError } from "@marlowe.io/adapter/codec";
 
 import {
+  AddressBech32,
   AddressesAndCollaterals,
   PayoutId,
   TextEnvelopeGuard,
+  TxOutRef,
   WithdrawalId,
   unAddressBech32,
   unTxOutRef,
@@ -94,13 +96,20 @@ export const GETByRangeResponse = t.type({
   nextRange: optionFromNullable(WithdrawalsRange),
 });
 
+export type WithdrawPayoutsRequest = {
+  payoutIds: PayoutId[];
+  changeAddress: AddressBech32;
+  usedAddresses?: AddressBech32[];
+  collateralUTxOs?: TxOutRef[];
+};
+
 export type POST = (
   payoutIds: PayoutId[],
   addressesAndCollaterals: AddressesAndCollaterals
-) => TE.TaskEither<Error | DecodingError, WithdrawalTextEnvelope>;
+) => TE.TaskEither<Error | DecodingError, WithdrawPayoutsResponse>;
 
-export type WithdrawalTextEnvelope = t.TypeOf<typeof WithdrawalTextEnvelope>;
-export const WithdrawalTextEnvelope = t.type({
+export type WithdrawPayoutsResponse = t.TypeOf<typeof WithdrawPayoutsResponse>;
+export const WithdrawPayoutsResponse = t.type({
   withdrawalId: WithdrawalId,
   tx: TextEnvelopeGuard,
 });
@@ -108,7 +117,7 @@ export const WithdrawalTextEnvelope = t.type({
 export type PostResponse = t.TypeOf<typeof PostResponse>;
 export const PostResponse = t.type({
   links: t.type({}),
-  resource: WithdrawalTextEnvelope,
+  resource: WithdrawPayoutsResponse,
 });
 
 /**


### PR DESCRIPTION
`createWithdrawal` was named `withdrawPayouts` to match naming used in the Runtime Rest API documentation ([`withdrawPayouts`](https://docs.marlowe.iohk.io/api/withdraw-payouts)).