### PR TITLE
Add annotations to rest client flow

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ The **Marlowe TS-SDK** is a suite of _TypeScript/JavaScript_ libraries for devel
 
 It is composed of several npm packages documented in the [API reference](https://input-output-hk.github.io/marlowe-ts-sdk/) page.
 
-## Prerequesites
+## Prerequisites
 
 In order to start working with the Marlowe SDK you need to have a URL to a running instance of the Marlowe Runtime and one of the supported wallet extensions installed in your browser.
 

--- a/doc/howToDevelop.md
+++ b/doc/howToDevelop.md
@@ -33,12 +33,12 @@ $ npm run test
 
 ## E2E tests
 
-In order to run the E2E tests you need to create a `./env/.env.test` file that points to a working version of the marlowe runtime and a working Blockfrost instance and a faucet PK.
+In order to run the E2E tests you need to create a `./env/.env.test` file that points to a working version of the Marlowe runtime and a working Blockfrost instance and a faucet PK.
 
 If you haven't done it before, go to https://blockfrost.io/ and create a free-tier account. Then, create a project and copy the project ID. Blockfrost is a Lucid dependency, eventually when
 we migrate to a different library this wont be necessary.
 
-To create an instance of a local marlowe runtime, follow the instructions in the [marlowe starter kit](https://github.com/input-output-hk/marlowe-starter-kit/blob/main/docs/preliminaries.md)
+To create an instance of a local Marlowe runtime, follow the instructions in the [Marlowe starter kit](https://github.com/input-output-hk/marlowe-starter-kit/blob/main/docs/preliminaries.md)
 
 TODO: explain how to get the Faucet PK
 
@@ -101,7 +101,7 @@ To collect all changelog entries into a single file, execute `std` from the nix 
 
 For the moment the SDK is manually published to npm. Task PLT-6939 captures the work to automate this process through the CI.
 
-Before publishing it is convinient to check that the artifacts works as expected :
+Before publishing it's convenient to verify that the artifacts works as expected :
 
 - Clean & Build
 

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -18,7 +18,7 @@ At the root of the project :
 npx http-server --port 1337 -c-1  -o ./
 ```
 
-Then select one of the availble examples:
+Then select one of the available examples:
 
 - [wallet flow](./wallet-flow/): Simple example on how to use the `@marlowe.io/wallet` package to connect to a wallet extension and get basic info and to manually sign transactions.
 - [Rest client flow](./rest-client-flow/): Shows how to use the `@marlowe.io/runtime-rest-client` package.

--- a/examples/rest-client-flow/index.html
+++ b/examples/rest-client-flow/index.html
@@ -90,7 +90,7 @@
         value="Get contract transaction by id"
         class="endpoint"
       />
-      GETs contract transaction by ID<a href="https://input-output-hk.github.io/marlowe-ts-sdk/interfaces/_marlowe_io_runtime_rest_client.index.RestAPI.html#getContractTransactionById">/contracts/:contractId/transactions/:transactionId</a>
+      GETs contract transaction by ID <a href="https://input-output-hk.github.io/marlowe-ts-sdk/interfaces/_marlowe_io_runtime_rest_client.index.RestAPI.html#getContractTransactionById">/contracts/:contractId/transactions/:transactionId</a>
       <br />
     </div>
 

--- a/examples/rest-client-flow/index.html
+++ b/examples/rest-client-flow/index.html
@@ -42,6 +42,7 @@
         value="Healthcheck"
         class="endpoint"
       />
+      GETs runtime status with <a href="https://input-output-hk.github.io/marlowe-ts-sdk/interfaces/_marlowe_io_runtime_rest_client.index.RestAPI.html#healthcheck">/healthcheck</a>
       <br />
       <input
         id="getContracts"
@@ -49,6 +50,7 @@
         value="Get Contracts"
         class="endpoint"
       />
+      GETs contracts from <a href="https://input-output-hk.github.io/marlowe-ts-sdk/interfaces/_marlowe_io_runtime_rest_client.index.RestAPI.html#getContracts">/contracts</a>
       <br />
       <input
         id="getContractById"
@@ -56,6 +58,7 @@
         value="Get Contract by id"
         class="endpoint"
       />
+      GETs contracts from <a href="https://input-output-hk.github.io/marlowe-ts-sdk/interfaces/_marlowe_io_runtime_rest_client.index.RestAPI.html#getContractById">/contracts/:contractId</a>
       <br />
       <input
         id="createContract"
@@ -63,6 +66,7 @@
         value="Create Contract"
         class="endpoint"
       />
+      POSTs a new contract using header parameters <a href="https://input-output-hk.github.io/marlowe-ts-sdk/interfaces/_marlowe_io_runtime_rest_client.index.RestAPI.html#createContract">/contracts</a>
       <br />
       <input
         id="submitContract"
@@ -70,6 +74,7 @@
         value="Submit Contract"
         class="endpoint"
       />
+      PUTs a signed transaction through <a href="https://input-output-hk.github.io/marlowe-ts-sdk/interfaces/_marlowe_io_runtime_rest_client.index.RestAPI.html#submitContract">/contracts/:contractId</a>
       <br />
       <input
         id="getTransactionsForContract"
@@ -77,6 +82,7 @@
         value="Get Transactions For Contract"
         class="endpoint"
       />
+      GETs transactions from a contract ID <a href="https://input-output-hk.github.io/marlowe-ts-sdk/interfaces/_marlowe_io_runtime_rest_client.index.RestAPI.html#getTransactionsForContract">/contracts/:contractId/transactions</a>
       <br />
       <input
         id="getContractTransactionById"
@@ -84,6 +90,7 @@
         value="Get contract transaction by id"
         class="endpoint"
       />
+      GETs contract transaction by ID<a href="https://input-output-hk.github.io/marlowe-ts-sdk/interfaces/_marlowe_io_runtime_rest_client.index.RestAPI.html#getContractTransactionById">/contracts/:contractId/transactions/:transactionId</a>
       <br />
     </div>
 

--- a/packages/adapter/Readme.md
+++ b/packages/adapter/Readme.md
@@ -1,3 +1,3 @@
 # Description
 
-A Set of small functionalities that supports @marlowe.io libraries. It is not intended to be used directly by end users, it is used by other libraries in the SDK.
+A Set of small functionalities that supports @marlowe.io libraries. This library is intended to be used internally in the SDK rather than externally by end users.


### PR DESCRIPTION
When running through various flows on examples, it is helpful to know what kind of parameters are required by the request since some do not require any while others might be more involved.

If the examples are staying on preprod, we could consider an explicit example using a known contract ID.