### PR TITLE
PLT-8770 - Fix the way importmaps are loaded in the examples folder

### DIFF
--- a/changelog.d/20231123_162544_hrajchert_plt_8770_fix_importmap.md
+++ b/changelog.d/20231123_162544_hrajchert_plt_8770_fix_importmap.md
@@ -1,0 +1,3 @@
+### General
+
+- Fix how importmaps are loaded in the examples folder

--- a/doc/modules-system.md
+++ b/doc/modules-system.md
@@ -9,7 +9,7 @@ The Marlowe SDK is built using ESM modules but one of its dependencies (fp-ts) d
 In most packages documentation you'll find something like:
 
 ```html
-<script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk@0.2.0-alpha-22/jsdelivr-npm-importmap.js"></script>
 <script type="module">
   import * as wallet from "@marlowe.io/wallet";
   // ...

--- a/examples/Readme.md
+++ b/examples/Readme.md
@@ -1,21 +1,33 @@
 ## Overview
 
-The examples on this folder demonstrate how to run the different libraries within a simple HTML page.
+The examples on this folder demonstrate how to run the different packages within a simple HTML page.
 
 ## How to run
 
-### Using Chrome
-
-#### Prerequisites
+### Prerequisites
 
 - A CIP30 wallet  (Nami, Eternl or Lace) installed on the browser.
+- [Node.js](https://nodejs.org/en/) installed on your machine.
 
-#### Flow
+### Flow
 
-At the root of the project :
+Make sure that you have development dependencies installed:
 
 ```bash
-npx http-server --port 1337 -c-1  -o ./
+npm install
+```
+
+Then run the following command to start a local server:
+
+```bash
+npm run serve
+```
+
+The previous command will start a local server on port 1337 and with the latest published libraries. If you want to use the local version instead, run the following command:
+
+```bash
+npm run build
+npm run serve-dev
 ```
 
 Then select one of the available examples:

--- a/examples/get-my-contract-ids-flow/index.html
+++ b/examples/get-my-contract-ids-flow/index.html
@@ -5,37 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Get my contract ids</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <script type="importmap">
-      {
-        "imports": {
-          "@marlowe.io/adapter": "/packages/adapter/dist/bundled/esm/adapter.js",
-          "@marlowe.io/adapter/codec": "/packages/adapter/dist/bundled/esm/codec.js",
-          "@marlowe.io/adapter/file": "/packages/adapter/dist/bundled/esm/file.js",
-          "@marlowe.io/adapter/fp-ts": "/packages/adapter/dist/bundled/esm/fp-ts.js",
-          "@marlowe.io/adapter/http": "/packages/adapter/dist/bundled/esm/http.js",
-          "@marlowe.io/adapter/time": "/packages/adapter/dist/bundled/esm/time.js",
-          "@marlowe.io/language-core-v1": "/packages/language/core/v1/dist/bundled/esm/language-core-v1.js",
-          "@marlowe.io/language-core-v1/guards": "/packages/language/core/v1/dist/bundled/esm/guards.js",
-          "@marlowe.io/language-core-v1/next": "/packages/language/core/v1/dist/bundled/esm/next.js",
-          "@marlowe.io/language-core-v1/version": "/packages/language/core/v1/dist/bundled/esm/version.js",
-          "@marlowe.io/language-examples": "/packages/language/examples/dist/bundled/esm/language-examples.js",
-          "@marlowe.io/token-metadata-client": "/packages/token-metadata-client/dist/bundled/esm/token-metadata-client.js",
-          "@marlowe.io/wallet": "/packages/wallet/dist/bundled/esm/wallet.js",
-          "@marlowe.io/wallet/api": "/packages/wallet/dist/bundled/esm/api.js",
-          "@marlowe.io/wallet/browser": "/packages/wallet/dist/bundled/esm/browser.js",
-          "@marlowe.io/wallet/nodejs": "/packages/wallet/dist/bundled/esm/nodejs.js",
-          "@marlowe.io/runtime-rest-client": "/packages/runtime/client/rest/dist/bundled/esm/runtime-rest-client.js",
-          "@marlowe.io/runtime-rest-client/transaction": "/packages/runtime/client/rest/dist/bundled/esm/transaction.js",
-          "@marlowe.io/runtime-rest-client/withdrawal": "/packages/runtime/client/rest/dist/bundled/esm/withdrawal.js",
-          "@marlowe.io/runtime-core": "/packages/runtime/core/dist/bundled/esm/runtime-core.js",
-          "@marlowe.io/runtime-lifecycle": "/packages/runtime/lifecycle/dist/bundled/esm/runtime-lifecycle.js",
-          "@marlowe.io/runtime-lifecycle/api": "/packages/runtime/lifecycle/dist/bundled/esm/api.js",
-          "@marlowe.io/runtime-lifecycle/browser": "/packages/runtime/lifecycle/dist/bundled/esm/browser.js",
-          "@marlowe.io/runtime-lifecycle/generic": "/packages/runtime/lifecycle/dist/bundled/esm/generic.js",
-          "lucid-cardano": "https://unpkg.com/lucid-cardano@0.10.7/web/mod.js"
-        }
-      }
-    </script>
+     <!-- This import map tells the browser what version of the SDK to use, the route is rewritten by the
+        local web server to point to the correct version -->
+    <script src="/importmap"></script>
   </head>
   <body></body>
   <script type="module">

--- a/examples/payouts-flow/index.html
+++ b/examples/payouts-flow/index.html
@@ -12,11 +12,9 @@
     <input id="start-flow" type="button" value="Start flow" />
     <hr />
     <div id="console"></div>
-    <!-- This import map tells the browser what version of the SDK to use, use the local-importmap for local
-         development and the jsdelivr importmap for the latest published version.
-    -->
-    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
-    <!--script src="/dist/local-importmap.js"></!--script-->
+    <!-- This import map tells the browser what version of the SDK to use, the route is rewritten by the
+        local web server to point to the correct version -->
+    <script src="/importmap"></script>
     <script type="module">
       import {
         mkBrowserWallet,

--- a/examples/rest-client-flow/index.html
+++ b/examples/rest-client-flow/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rest Client Flow</title>
+    <!-- This import map tells the browser what version of the SDK to use, the route is rewritten by the
+        local web server to point to the correct version -->
+    <script src="/importmap"></script>
   </head>
   <body>
     <h1>Rest Client Flow</h1>
@@ -138,11 +141,6 @@
     <input id="clear-console" type="button" value="Clear console" />
     <div id="console"></div>
 
-    <!-- This import map tells the browser what version of the SDK to use, use the local-importmap for local
-         development and the jsdelivr importmap for the latest published version.
-      -->
-    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
-    <!--script src="/dist/local-importmap.js"></script-->
     <script type="module">
       import { mkRestClient } from "@marlowe.io/runtime-rest-client";
       import { MarloweJSON } from "@marlowe.io/adapter/codec";

--- a/examples/run-lite/index.html
+++ b/examples/run-lite/index.html
@@ -6,11 +6,9 @@
     <title>Marlowe Run Very Lite POC</title>
   </head>
   <body>
-    <!-- This import map tells the browser what version of the SDK to use, use the local-importmap for local
-         development and the jsdelivr importmap for the latest published version.
-      -->
-    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
-    <!--script src="/dist/local-importmap.js"></!--script-->
+    <!-- This import map tells the browser what version of the SDK to use, the route is rewritten by the
+        local web server to point to the correct version -->
+    <script src="/importmap"></script>
 
     <h1>Marlowe Run Lite Lite</h1>
     <div>

--- a/examples/survey-workshop/custodian/index.html
+++ b/examples/survey-workshop/custodian/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Marlowe Workshop - Survey Custodian</title>
+     <!-- This import map tells the browser what version of the SDK to use, the route is rewritten by the
+        local web server to point to the correct version -->
+    <script src="/importmap"></script>
   </head>
   <body>
     <h1>Marlowe Workshop - Survey Custodian</h1>
@@ -52,12 +55,6 @@
     <h2>Console</h2>
     <input id="clear-console" type="button" value="Clear console" />
     <div id="console"></div>
-
-    <!-- This import map tells the browser what version of the SDK to use, use the local-importmap for local
-         development and the jsdelivr importmap for the latest published version.
-      -->
-    <!--script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></!--script-->
-    <script src="/dist/local-importmap.js"></script>
     <script src="https:/cdn.jsdelivr.net/npm/jsencrypt/bin/jsencrypt.min.js"></script>
 
     <script type="module" src="index.js"></script>

--- a/examples/survey-workshop/participant/index.html
+++ b/examples/survey-workshop/participant/index.html
@@ -20,6 +20,9 @@
 
     <!-- lz-string compression -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.5.0/lz-string.min.js"></script>
+    <!-- This import map tells the browser what version of the SDK to use, the route is rewritten by the
+        local web server to point to the correct version -->
+    <script src="/importmap"></script>
   <title>Marlowe Workshop - Survey Participant</title>
 </head>
 
@@ -312,11 +315,6 @@
       </div>
     </div>
   </div>
-  <!-- This import map tells the browser what version of the SDK to use, use the local-importmap for local
-         development and the jsdelivr importmap for the latest published version.
-      -->
-  <!--script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></!--script-->
-  <script src="/dist/local-importmap.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jsencrypt/bin/jsencrypt.min.js"></script>
 
   <script type="module" src="index.js"></script>

--- a/examples/vesting-flow/index.html
+++ b/examples/vesting-flow/index.html
@@ -5,11 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Vesting Flow</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- This import map tells the browser what version of the SDK to use, use the local-importmap for local
-         development and the jsdelivr importmap for the latest published version.
-    -->
-    <!-- <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script> -->
-    <script src="/dist/local-importmap.js"></script>
+    <!-- This import map tells the browser what version of the SDK to use, the route is rewritten by the
+        local web server to point to the correct version -->
+    <script src="/importmap"></script>
   </head>
   <body>
     <div>

--- a/examples/wallet-flow/index.html
+++ b/examples/wallet-flow/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WalletAPI smoke test</title>
+    <!-- This import map tells the browser what version of the SDK to use, the route is rewritten by the
+        local web server to point to the correct version -->
+    <script src="/importmap"></script>
   </head>
   <body>
     <label for="wallet">Select wallet:</label>
@@ -24,11 +27,6 @@
     <hr />
 
     <div id="console"></div>
-    <!-- This import map tells the browser what version of the SDK to use, use the local-importmap for local
-         development and the jsdelivr importmap for the latest published version.
-      -->
-    <!-- <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script> -->
-    <script src="/dist/local-importmap.js"></script>
     <script type="module">
       import { clearConsole, log } from "../js/poc-helpers.js";
       import {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "build": "tsc --build && shx mkdir -p dist && rollup --config rollup/config.mjs",
     "clean": "npm run clean --workspaces && shx rm -rf dist",
     "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest",
-    "docs": "typedoc ."
+    "docs": "typedoc .",
+    "serve": "ws --port 1337 --rewrite '/importmap -> https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk@0.2.0-alpha-22/jsdelivr-npm-importmap.js'",
+    "serve-dev": "ws --port 1337 --rewrite '/importmap -> /dist/local-importmap.js'"
   },
   "workspaces": [
     "packages/adapter",
@@ -53,6 +55,7 @@
     "http-server": "^14.1.1",
     "jest": "^29.4",
     "jest-serial-runner": "^1.2.1",
+    "local-web-server": "^5.3.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.2",
     "rollup": "^3.27.2",

--- a/packages/language/core/v1/Readme.md
+++ b/packages/language/core/v1/Readme.md
@@ -17,7 +17,7 @@ This package is [released as an ESM module](https://github.com/input-output-hk/m
 ```html
 <html>
   <body>
-    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk@0.2.0-alpha-22/jsdelivr-npm-importmap.js"></script>
     <script type="module">
       import { Contract } from "@marlowe.io/language-core-v1/guards";
       const jsonObject = JSON.parse(httpResponse);

--- a/packages/runtime/client/rest/Readme.md
+++ b/packages/runtime/client/rest/Readme.md
@@ -17,7 +17,7 @@ The caller should run a `healthcheck` to ensure the runtime service is healthy t
 ```html
 <html>
   <body>
-    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk@0.2.0-alpha-22/jsdelivr-npm-importmap.js"></script>
     <script type="module">
       import { mkRestClient } from "@marlowe.io/runtime-rest-client";
 

--- a/packages/runtime/lifecycle/Readme.md
+++ b/packages/runtime/lifecycle/Readme.md
@@ -11,7 +11,7 @@ The `@marlowe.io/lifecycle` package is [released as an ESM module](https://githu
 ```html
 <html>
   <body>
-    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk@0.2.0-alpha-22/jsdelivr-npm-importmap.js"></script>
     <script type="module">
       import { mkRuntimeLifecycle } from "@marlowe.io/runtime-lifecycle/browser";
       const walletName = "nami";

--- a/packages/wallet/Readme.md
+++ b/packages/wallet/Readme.md
@@ -20,7 +20,7 @@ The `@marlowe.io/wallet` package is [released as an ESM module](https://github.c
 ```html
 <html>
   <body>
-    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk/jsdelivr-npm-importmap.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk@0.2.0-alpha-22/jsdelivr-npm-importmap.js"></script>
     <script type="module">
       import {
         mkBrowserWallet,


### PR DESCRIPTION
Currently each example has a script to either the local build or github main to load the import maps that control which version of the SDK is loaded. 

This is cumbersome, as you need to comment one and enable the other (and remember to always keep the github one when committing) and also unstable as the github one can change without you knowing it and break the example.

This PR changes the way the examples are loaded, and instead of using `http-server` we use `local-web-server` which allows for URL rewrite rules. 

Now, the way you host the examples is either

```
npm run serve
```

to use the latest release, or 

```
npm run serve-dev
```

to use the local build.

**IMPORTANT**
As part of this work, we need to add a tag when we make a release (eventually from the CI this should be done automatically) and update the script entry in the main package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - General fix for how importmaps are loaded, enhancing the stability of example applications.

- **Documentation**
  - Updated the Marlowe SDK's dependency documentation to reflect the new version.
  - Improved the examples' README with clearer instructions and prerequisites.
  - Aligned terminology from "libraries" to "packages" for consistency.

- **Refactor**
  - Streamlined the import mechanism for the SDK across various example applications.
  - Transitioned from remote CDN to local import maps for SDK version management.

- **Chores**
  - Updated script source URLs to pin the Marlowe TypeScript SDK to a specific version for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->