### PR TITLE
removed filter from getHeadersByRangeViaAxios

### DIFF
--- a/changelog.d/20231129_130322_franzavalla85_PLT_8828_remove_filter_getContracts_response.md
+++ b/changelog.d/20231129_130322_franzavalla85_PLT_8828_remove_filter_getContracts_response.md
@@ -1,7 +1,3 @@
-### General
-
-- Allows to filter tags one by one on `getContracts` endpoint
-
 ### @marlowe.io/runtime-rest-client
 
 - Removed filter from return on `getContracts` endpoint

--- a/changelog.d/20231129_130322_franzavalla85_PLT_8828_remove_filter_getContracts_response.md
+++ b/changelog.d/20231129_130322_franzavalla85_PLT_8828_remove_filter_getContracts_response.md
@@ -1,0 +1,7 @@
+### General
+
+- Allows to filter tags one by one on `getContracts` endpoint
+
+### @marlowe.io/runtime-rest-client
+
+- Removed filter from return on `getContracts` endpoint

--- a/packages/runtime/client/rest/src/contract/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/contract/endpoints/collection.ts
@@ -133,18 +133,12 @@ export const getHeadersByRangeViaAxios: (
       TE.map((rawResponse) => ({
         headers: pipe(
           rawResponse.data.results,
-          A.map((result) => result.resource),
-          A.filter((header) =>
-            eqSetString(new Set(Object.keys(header.tags)), new Set(tags))
-          )
+          A.map((result) => result.resource)
         ), // All logic instead of Any, TODO : Add the flexibility to chose between Any and All
         previousRange: rawResponse.previousRange,
         nextRange: rawResponse.nextRange,
       }))
     );
-
-const eqSetString = (xs: Set<string>, ys: Set<string>) =>
-  xs.size === ys.size && [...xs].every((x) => ys.has(x));
 
 export type GETByRangeRawResponse = t.TypeOf<typeof GETByRangeRawResponse>;
 export const GETByRangeRawResponse = t.type({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the header retrieval process in the client by removing unnecessary string set comparisons and tag-based filtering.

- **Documentation**
  - Updated the changelog to reflect the ability to filter tags individually on the `getContracts` endpoint and the removal of the filter from the endpoint's return.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->