### PR TITLE
PLT-7704, PLT-7705: Extend Rest API with procedures getPayouts and getPayoutById

### DIFF
--- a/changelog.d/20231207_162300_bjorn.wilhelm.kihlberg_PLT_7704.md
+++ b/changelog.d/20231207_162300_bjorn.wilhelm.kihlberg_PLT_7704.md
@@ -1,0 +1,4 @@
+### @marlowe.io/runtime-rest-client
+
+- PLT-7704: Extend the rest client with procedure `getPayouts`. (Implemented in [PR-124](https://github.com/input-output-hk/marlowe-ts-sdk/pull/124))
+- PLT-7705: Extend the rest client with procedure `getPayoutById`. (Implemented in [PR-124](https://github.com/input-output-hk/marlowe-ts-sdk/pull/124))

--- a/packages/runtime/client/rest/src/index.ts
+++ b/packages/runtime/client/rest/src/index.ts
@@ -219,6 +219,13 @@ export interface RestClient {
     request: Payouts.GetPayoutsRequest
   ): Promise<Payouts.GetPayoutsResponse>;
 
+  /**
+   * Get payout information associated with payout ID
+   * @see {@link https://docs.marlowe.iohk.io/api/get-payout-by-id | The backend documentation}
+   */
+  getPayoutById(
+    request: Payout.GetPayoutByIdRequest
+  ): Promise<Payout.GetPayoutByIdResponse>;
 }
 
 /**
@@ -382,6 +389,23 @@ export function mkRestClient(baseURL: string): RestClient {
           () => ({}),
           (nextRange) => ({ nextRange })
         )(result.nextRange),
+      };
+    },
+    async getPayoutById({ payoutId }) {
+      const result = await unsafeTaskEither(
+        Payout.getViaAxios(axiosInstance)(payoutId)
+      );
+      return {
+        payoutId: result.payoutId,
+        contractId: result.contractId,
+        ...O.match(
+          () => ({}),
+          (withdrawalId) => ({ withdrawalId })
+        )(result.withdrawalId),
+        role: result.role,
+        payoutValidatorAddress: result.payoutValidatorAddress,
+        status: result.status,
+        assets: result.assets,
       };
     },
   };

--- a/packages/runtime/client/rest/src/index.ts
+++ b/packages/runtime/client/rest/src/index.ts
@@ -211,8 +211,14 @@ export interface RestClient {
   //   getContractAdjacency: ContractSource.GET_ADJACENCY;  // - Jamie, is it this one? https://docs.marlowe.iohk.io/api/get-adjacency-by-id if so lets unify
   //   getContractClosure: ContractSource.GET_CLOSURE; // Jamie is it this one? - https://docs.marlowe.iohk.io/api/get-closure-by-id
 
-  //   getPayouts: Payouts.GET;
-  //   getPayoutById: Payout.GET;
+  /**
+   * Get payouts to parties from role-based contracts.
+   * @see {@link https://docs.marlowe.iohk.io/api/get-role-payouts | The backend documentation}
+   */
+  getPayouts(
+    request: Payouts.GetPayoutsRequest
+  ): Promise<Payouts.GetPayoutsResponse>;
+
 }
 
 /**
@@ -360,6 +366,24 @@ export function mkRestClient(baseURL: string): RestClient {
           () => true
         )
       )(),
+    async getPayouts({ contractIds, roleTokens, range, status }) {
+      const result = await unsafeTaskEither(
+        Payouts.getHeadersByRangeViaAxios(axiosInstance)(O.fromNullable(range))(
+          contractIds
+        )(roleTokens)(O.fromNullable(status))
+      );
+      return {
+        headers: result.headers,
+        ...O.match(
+          () => ({}),
+          (previousRange) => ({ previousRange })
+        )(result.previousRange),
+        ...O.match(
+          () => ({}),
+          (nextRange) => ({ nextRange })
+        )(result.nextRange),
+      };
+    },
   };
 }
 

--- a/packages/runtime/client/rest/src/payout/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/payout/endpoints/collection.ts
@@ -26,6 +26,19 @@ export const ContractsRange = fromNewtype<ContractsRange>(t.string);
 export const unContractsRange = iso<ContractsRange>().unwrap;
 export const contractsRange = iso<ContractsRange>().wrap;
 
+export type GetPayoutsRequest = {
+  contractIds: ContractId[];
+  roleTokens: AssetId[];
+  status?: PayoutStatus;
+  range?: ContractsRange;
+};
+
+export type GetPayoutsResponse = {
+  headers: PayoutHeader[];
+  previousRange?: ContractsRange;
+  nextRange?: ContractsRange;
+};
+
 export type GETHeadersByRange = (
   rangeOption: O.Option<ContractsRange>
 ) => (

--- a/packages/runtime/client/rest/src/payout/endpoints/singleton.ts
+++ b/packages/runtime/client/rest/src/payout/endpoints/singleton.ts
@@ -10,8 +10,29 @@ import { formatValidationErrors } from "jsonbigint-io-ts-reporters";
 import * as HTTP from "@marlowe.io/adapter/http";
 import { DecodingError } from "@marlowe.io/adapter/codec";
 
-import { PayoutId, unPayoutId } from "@marlowe.io/runtime-core";
-import { PayoutDetails } from "../details.js";
+import {
+  AddressBech32,
+  AssetId,
+  ContractId,
+  PayoutId,
+  WithdrawalId,
+  unPayoutId,
+} from "@marlowe.io/runtime-core";
+import { PayoutStatus, PayoutDetails, Assets } from "../index.js";
+
+export type GetPayoutByIdRequest = {
+  payoutId: PayoutId;
+};
+
+export type GetPayoutByIdResponse = {
+  payoutId: PayoutId;
+  contractId: ContractId;
+  withdrawalId?: WithdrawalId;
+  role: AssetId;
+  payoutValidatorAddress: AddressBech32;
+  status: PayoutStatus;
+  assets: Assets;
+};
 
 export type GET = (
   payoutId: PayoutId


### PR DESCRIPTION
## Resolves issues
- [Issue 65](https://github.com/input-output-hk/marlowe-ts-sdk/issues/65)
- [Issue 66](https://github.com/input-output-hk/marlowe-ts-sdk/issues/66)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Users can now retrieve a list of payouts with the new `getPayouts` method.
  - Users can fetch details of a specific payout using the new `getPayoutById` method.

- **Enhancements**
  - Expanded the `RestClient` interface to support new payout retrieval functionalities.
  - Introduced new request and response types for payout operations, enhancing the data structure and clarity for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->