### PR TITLE
Add new endpoint to runtime-rest-clime: Get Status Endpoint

### DIFF
--- a/packages/adapter/src/io-ts.ts
+++ b/packages/adapter/src/io-ts.ts
@@ -1,5 +1,5 @@
 import * as t from "io-ts/lib/index.js";
-
+import { withValidate } from "io-ts-types";
 /**
  * In the TS-SDK we duplicate the type and guard definition for each type as the
  * inferred type from io-ts does not produce a good type export when used with
@@ -59,4 +59,19 @@ export function assertGuardEqual<A, G extends t.Type<A, any, any>>(
  */
 export function proxy<A = never>(): A {
   return null as any;
+}
+
+/**
+ * converts a null value to an undefined one.
+ * @returns
+ */
+export function convertNullableToUndefined<C extends t.Mixed>(
+  codec: C,
+  name = `fromNullableToUndefined(${codec.name})`
+): C {
+  return withValidate(
+    codec,
+    (u, c) => (u == null ? t.success(undefined) : codec.validate(u, c)),
+    name
+  );
 }

--- a/packages/runtime/client/rest/src/contract/details.ts
+++ b/packages/runtime/client/rest/src/contract/details.ts
@@ -1,4 +1,4 @@
-import { optionFromNullable } from "io-ts-types";
+import { fromNullable } from "io-ts-types";
 import * as t from "io-ts/lib/index.js";
 import { Contract, MarloweState } from "@marlowe.io/language-core-v1";
 import * as G from "@marlowe.io/language-core-v1/guards";
@@ -22,7 +22,11 @@ import {
   TextEnvelopeGuard,
   PolicyId,
 } from "@marlowe.io/runtime-core";
-import { assertGuardEqual, proxy } from "@marlowe.io/adapter/io-ts";
+import {
+  assertGuardEqual,
+  convertNullableToUndefined,
+  proxy,
+} from "@marlowe.io/adapter/io-ts";
 import { TxStatus } from "./transaction/status.js";
 
 // QUESTION: Where do we have global documentation about how Roles and payouts work?
@@ -92,9 +96,12 @@ export const ContractDetailsGuard = assertGuardEqual(
       metadata: Metadata,
       unclaimedPayouts: t.array(Payout),
     }),
-    t.partial({ currentContract: G.Contract, state: G.MarloweState }),
-    t.partial({ utxo: TxOutRef }),
-    t.partial({ block: BlockHeaderGuard }),
-    t.partial({ txBody: TextEnvelopeGuard }),
+    t.partial({
+      currentContract: convertNullableToUndefined(G.Contract),
+      state: convertNullableToUndefined(G.MarloweState),
+    }),
+    t.partial({ utxo: convertNullableToUndefined(TxOutRef) }),
+    t.partial({ block: convertNullableToUndefined(BlockHeaderGuard) }),
+    t.partial({ txBody: convertNullableToUndefined(TextEnvelopeGuard) }),
   ])
 );

--- a/packages/runtime/client/rest/src/index.ts
+++ b/packages/runtime/client/rest/src/index.ts
@@ -284,7 +284,7 @@ export function mkRestClient(baseURL: string): RestClient {
       );
     },
     getContractById(contractId) {
-      return unsafeTaskEither(Contract.getViaAxios(axiosInstance)(contractId));
+      return Contract.getContractById(axiosInstance, contractId);
     },
     buildCreateContractTx(request) {
       const postContractsRequest = {
@@ -584,7 +584,10 @@ export function mkFPTSRestClient(baseURL: string): FPTSRestAPI {
       getHeadersByRange: Contracts.getHeadersByRangeViaAxios(axiosInstance),
       post: Contracts.postViaAxios(axiosInstance),
       contract: {
-        get: Contract.getViaAxios(axiosInstance),
+        get: (contractId) =>
+          TE.fromTask(() =>
+            Contract.getContractById(axiosInstance, contractId)
+          ),
         put: Contract.putViaAxios(axiosInstance),
         next: Next.getViaAxios(axiosInstance),
         transactions: {

--- a/packages/runtime/client/rest/test/endpoints/contracts.spec.e2e.ts
+++ b/packages/runtime/client/rest/test/endpoints/contracts.spec.e2e.ts
@@ -10,7 +10,8 @@ describe("contracts endpoints", () => {
   const restClient = mkRestClient(getMarloweRuntimeUrl());
 
   it(
-    "can navigate throught Marlowe Contracts pages" + "(GET:  /contracts/)",
+    "can navigate throught some Marlowe Contracts pages" +
+      "(GET:  /contracts/)",
     async () => {
       const firstPage = await restClient.getContracts({
         tags: [],
@@ -38,6 +39,26 @@ describe("contracts endpoints", () => {
       expect(thirdPage.page.total).toBeGreaterThan(100);
 
       expect(thirdPage.page.next).toBeDefined();
+    },
+    100_000
+  );
+  it(
+    "can retrieve some contract Details" + "(GET:  /contracts/{contractId})",
+    async () => {
+      const firstPage = await restClient.getContracts({
+        tags: [],
+        partyAddresses: [],
+        partyRoles: [],
+      });
+      expect(firstPage.contracts.length).toBe(100);
+      expect(firstPage.page.total).toBeGreaterThan(100);
+      expect(firstPage.page.next).toBeDefined();
+
+      await Promise.all(
+        firstPage.contracts.map((contract) =>
+          restClient.getContractById(contract.contractId)
+        )
+      );
     },
     100_000
   );

--- a/packages/runtime/client/rest/test/endpoints/payouts.spec.e2e.ts
+++ b/packages/runtime/client/rest/test/endpoints/payouts.spec.e2e.ts
@@ -1,11 +1,4 @@
-import { pipe } from "fp-ts/lib/function.js";
-import * as TE from "fp-ts/lib/TaskEither.js";
-import * as O from "fp-ts/lib/Option.js";
-
-import {
-  mkFPTSRestClient,
-  mkRestClient,
-} from "@marlowe.io/runtime-rest-client";
+import { mkRestClient } from "@marlowe.io/runtime-rest-client";
 
 import { getMarloweRuntimeUrl } from "../context.js";
 


### PR DESCRIPTION
As part of resolving issue https://github.com/input-output-hk/marlowe-ts-sdk/issues/145 , the following 2 items were addressed

- [x] Added Runtime Status Endpoint  : In order for the E2E tests to work we need to make sure that the Tip information of the runtime is synchronized with lucid
- [x] As part of the testing, we noted that the response of `getContractById` was badly typed. 