### PR TITLE
PLT-9089: create contract bundle support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,12 @@
       "${workspaceFolder}/packages/runtime/client/rest/dist/esm/**/*.js",
       "${workspaceFolder}/packages/runtime/core/dist/esm/**/*.js",
       "${workspaceFolder}/packages/runtime/lifecycle/dist/esm/**/*.js",
-      "${workspaceFolder}/packages/marlowe-object/dist/esm/**/*.js"
+      "${workspaceFolder}/packages/marlowe-object/dist/esm/**/*.js",
+      "${workspaceFolder}/packages/runtime/lifecycle/test-dist/**/*.js",
+      "${workspaceFolder}/packages/runtime/client/rest/test-dist/**/*.js",
+      "${workspaceFolder}/packages/language/core/v1/test-dist/**/*.js",
+      "${workspaceFolder}/packages/language/examples/test-dist/**/*.js",
+      "${workspaceFolder}/packages/wallet/test-dist/**/*.js"
     ]
   }
 }

--- a/changelog.d/20240112_130130_hrajchert_plt_9089_createContract_bundle_support.md
+++ b/changelog.d/20240112_130130_hrajchert_plt_9089_createContract_bundle_support.md
@@ -1,0 +1,5 @@
+
+### @marlowe.io/runtime-lifecycle
+
+- Added support for contract bundles in the `lifecycle.contracts.createContract` function. ([PR-167](https://github.com/input-output-hk/marlowe-ts-sdk/pull/167))
+

--- a/doc/howToDevelop.md
+++ b/doc/howToDevelop.md
@@ -59,64 +59,23 @@ $ npm test
 
 ### Setting up the env Configuration File
 
-1. Create a `./env/.env.test` at the root of the project
+1. Create a `./env/.test-env.json` at the root of the project
 2. Copy/Paste the following, and provide the necessary parameter
 
-```bash
-####################################################
-## Provide a Runtime Instance URL (>= v0.0.5)      #
-####################################################
-## to create an instance of a local Marlowe runtime, follow the instructions in
-## the Marlowe starter kit : https://github.com/input-output-hk/ marlowe-starter-kit/blob/main/docs/preliminaries.md
-MARLOWE_WEB_SERVER_URL="http://<path-to-a-runtime-instance>:<a-port>"
-####################################################
-
-#####################################################
-## Provide Wallet Dependencies (Necessary for Lucid Library)
-#####################################################
-## Blockfrost Account :  If you haven't done it before, go to https://blockfrost.io/ and create a free-tier account.
-## Then, create a project and copy the project ID
-BLOCKFROST_PROJECT_ID="<your-blockfrost-project-id>"
-BLOCKFROST_URL="<your-blockfrost-id>"
-## Network used by Blockfrost : private | preview | preprod | mainnet
-NETWORK_NAME=preprod
-## Bank Seed Phrase : The bank is a wallet where you provision enough tAda (>= 100 tAda) to run all
-## the e2e tests without running out of money. This is your responsability to create this wallet and
-## add tAda using a Faucet.
-BANK_SEED_PHRASE='[
-    "deal",
-    "place",
-    "depart",
-    "sound",
-    "kick",
-    "daughter",
-    "diamond",
-    "rebel",
-    "update",
-    "shoe",
-    "benefit",
-    "useful",
-    "travel",
-    "fringe",
-    "culture",
-    "dog",
-    "lawsuit",
-    "combine",
-    "run",
-    "vanish",
-    "warm",
-    "rubber",
-    "quit",
-    "system"
-]'
-#####################################################
-
-#####################################################
-## Logging
-#####################################################
-## set to true or false if you want to log Debug Info
-LOG_DEBUG_LEVEL=false
+```json
+{
+  "bank": {
+    "seedPhrase": "<seed phrase separated by spaces>"
+  },
+  "lucid": {
+    "blockfrostProjectId": "<your-blockfrost-project-id>",
+    "blockfrostUrl": "<your-blockfrost-url>"
+  },
+  "network": "Preprod",
+  "runtimeURL": "http://<path-to-a-runtime-instance>:<a-port>"
+}
 ```
+
 #### How to Generate a new Seed Phrase for a Bank Wallet ?
 
 1. At the root of the project :

--- a/examples/nodejs/src/marlowe-object-flow.ts
+++ b/examples/nodejs/src/marlowe-object-flow.ts
@@ -567,26 +567,12 @@ async function createContract(
 ): Promise<[ContractId, TxId]> {
   const contractBundle = mkDelayPayment(schema);
   const tags = mkDelayPaymentTags(schema);
-  // TODO: PLT-9089: Modify runtimeLifecycle.contracts.createContract to support bundle (calling createContractSources)
-  const contractSources =
-    await lifecycle.restClient.createContractSources(contractBundle);
-  const walletAddress = await lifecycle.wallet.getChangeAddress();
-  const unsignedTx = await lifecycle.restClient.buildCreateContractTx({
-    sourceId: contractSources.contractSourceId,
-    tags,
-    changeAddress: walletAddress,
+  return lifecycle.contracts.createContract({
     stakeAddress: rewardAddress,
+    bundle: contractBundle,
+    tags,
     minimumLovelaceUTxODeposit: 3_000_000,
-    version: "v1",
   });
-  const signedCborHex = await lifecycle.wallet.signTx(unsignedTx.tx.cborHex);
-  await lifecycle.restClient.submitContract(
-    unsignedTx.contractId,
-    transactionWitnessSetTextEnvelope(signedCborHex)
-  );
-  const txId = contractIdToTxId(unsignedTx.contractId);
-  return [unsignedTx.contractId, txId];
-  //----------------
 }
 
 type ValidationResults = "InvalidTags" | "InvalidContract" | DelayPaymentScheme;

--- a/packages/runtime/client/rest/test/endpoints/contracts.spec.e2e.ts
+++ b/packages/runtime/client/rest/test/endpoints/contracts.spec.e2e.ts
@@ -1,4 +1,5 @@
-import { readEnvConfigurationFile } from "@marlowe.io/testing-kit";
+import { mkRestClient } from "@marlowe.io/runtime-rest-client";
+import { readTestConfiguration } from "@marlowe.io/testing-kit";
 
 import console from "console";
 
@@ -9,8 +10,9 @@ describe("contracts endpoints", () => {
     "can navigate throught some Marlowe Contracts pages" +
       "(GET:  /contracts/)",
     async () => {
-      const { runtime } = await readEnvConfigurationFile();
-      const firstPage = await runtime.client.getContracts({
+      const config = await readTestConfiguration();
+      const restClient = mkRestClient(config.runtimeURL);
+      const firstPage = await restClient.getContracts({
         tags: [],
         partyAddresses: [],
         partyRoles: [],
@@ -20,7 +22,7 @@ describe("contracts endpoints", () => {
 
       expect(firstPage.page.next).toBeDefined();
 
-      const secondPage = await runtime.client.getContracts({
+      const secondPage = await restClient.getContracts({
         range: firstPage.page.next,
       });
       expect(secondPage.contracts.length).toBe(100);
@@ -28,7 +30,7 @@ describe("contracts endpoints", () => {
 
       expect(secondPage.page.next).toBeDefined();
 
-      const thirdPage = await runtime.client.getContracts({
+      const thirdPage = await restClient.getContracts({
         range: secondPage.page.next,
       });
 
@@ -42,8 +44,10 @@ describe("contracts endpoints", () => {
   it(
     "can retrieve some contract Details" + "(GET:  /contracts/{contractId})",
     async () => {
-      const { runtime } = await readEnvConfigurationFile();
-      const firstPage = await runtime.client.getContracts({
+      const config = await readTestConfiguration();
+      const restClient = mkRestClient(config.runtimeURL);
+
+      const firstPage = await restClient.getContracts({
         tags: [],
         partyAddresses: [],
         partyRoles: [],
@@ -54,7 +58,7 @@ describe("contracts endpoints", () => {
 
       await Promise.all(
         firstPage.contracts.map((contract) =>
-          runtime.client.getContractById(contract.contractId)
+          restClient.getContractById(contract.contractId)
         )
       );
     },

--- a/packages/runtime/client/rest/test/endpoints/payouts.spec.e2e.ts
+++ b/packages/runtime/client/rest/test/endpoints/payouts.spec.e2e.ts
@@ -1,5 +1,5 @@
 import { mkRestClient } from "@marlowe.io/runtime-rest-client";
-import { readEnvConfigurationFile } from "@marlowe.io/testing-kit";
+import { readTestConfiguration } from "@marlowe.io/testing-kit";
 
 import console from "console";
 global.console = console;
@@ -8,8 +8,10 @@ describe("payouts endpoints", () => {
   it(
     "can navigate throught payout headers" + "(GET:  /payouts)",
     async () => {
-      const { runtime } = await readEnvConfigurationFile();
-      const firstPage = await runtime.client.getPayouts({
+      const config = await readTestConfiguration();
+      const restClient = mkRestClient(config.runtimeURL);
+
+      const firstPage = await restClient.getPayouts({
         contractIds: [],
         roleTokens: [],
       });
@@ -18,7 +20,7 @@ describe("payouts endpoints", () => {
 
       expect(firstPage.page.next).toBeDefined();
 
-      const secondPage = await runtime.client.getPayouts({
+      const secondPage = await restClient.getPayouts({
         contractIds: [],
         roleTokens: [],
         range: firstPage.page.next,
@@ -28,7 +30,7 @@ describe("payouts endpoints", () => {
 
       expect(secondPage.page.next).toBeDefined();
 
-      const thirdPage = await runtime.client.getPayouts({
+      const thirdPage = await restClient.getPayouts({
         contractIds: [],
         roleTokens: [],
         range: secondPage.page.next,

--- a/packages/runtime/lifecycle/src/generic/contracts.ts
+++ b/packages/runtime/lifecycle/src/generic/contracts.ts
@@ -30,10 +30,7 @@ import {
 import { DecodingError } from "@marlowe.io/adapter/codec";
 
 import { Next, noNext } from "@marlowe.io/language-core-v1/next";
-import {
-  BuildCreateContractTxResponse,
-  TransactionTextEnvelope,
-} from "@marlowe.io/runtime-rest-client/contract";
+import { TransactionTextEnvelope } from "@marlowe.io/runtime-rest-client/contract";
 import { SingleInputTx } from "@marlowe.io/language-core-v1/transaction.js";
 import { iso8601ToPosixTime } from "@marlowe.io/adapter/time";
 
@@ -44,7 +41,7 @@ export function mkContractLifecycle(
 ): ContractsAPI {
   const di = { wallet, deprecatedRestAPI, restClient };
   return {
-    createContract: submitCreateTx(di),
+    createContract: createContract(di),
     applyInputs: applyInputsTx(di),
     getApplicableInputs: getApplicableInputs(di),
     getContractIds: getContractIds(di),
@@ -99,14 +96,42 @@ const getInputHistory =
       .flat();
   };
 
-const submitCreateTx =
+const createContract =
   ({ wallet, restClient }: ContractsDI) =>
-  (
+  async (
     createContractRequest: CreateContractRequest
   ): Promise<[ContractId, TxId]> => {
-    return unsafeTaskEither(
-      submitCreateTxFpTs(restClient)(wallet)(createContractRequest)
+    const addressesAndCollaterals = await getAddressesAndCollaterals(wallet);
+
+    const buildCreateContractTxResponse =
+      await restClient.buildCreateContractTx({
+        version: "v1",
+
+        changeAddress: addressesAndCollaterals.changeAddress,
+        usedAddresses: addressesAndCollaterals.usedAddresses,
+        collateralUTxOs: addressesAndCollaterals.collateralUTxOs,
+        stakeAddress: createContractRequest.stakeAddress,
+
+        contract: createContractRequest.contract,
+        threadRoleName: createContractRequest.threadRoleName,
+        roles: createContractRequest.roles,
+
+        tags: createContractRequest.tags,
+        metadata: createContractRequest.metadata,
+        minimumLovelaceUTxODeposit:
+          createContractRequest.minimumLovelaceUTxODeposit,
+      });
+    const contractId = buildCreateContractTxResponse.contractId;
+
+    const hexTransactionWitnessSet = await wallet.signTx(
+      buildCreateContractTxResponse.tx.cborHex
     );
+
+    await restClient.submitContract(
+      contractId,
+      transactionWitnessSetTextEnvelope(hexTransactionWitnessSet)
+    );
+    return [contractId, contractIdToTxId(contractId)];
   };
 
 const applyInputsTx =
@@ -188,74 +213,6 @@ const getParties: (
       .map((token) => ({ role_token: token.assetId.policyId }));
     return roles.concat([changeAddress]).concat(usedAddresses);
   };
-
-export const submitCreateTxFpTs: (
-  client: RestClient
-) => (
-  wallet: WalletAPI
-) => (
-  createContractRequest: CreateContractRequest
-) => TE.TaskEither<Error | DecodingError, [ContractId, TxId]> =
-  (client) => (wallet) => (createContractRequest) =>
-    pipe(
-      tryCatchDefault(() => getAddressesAndCollaterals(wallet)),
-      TE.chain((addressesAndCollaterals) =>
-        tryCatchDefault(() =>
-          client.buildCreateContractTx({
-            version: "v1",
-
-            changeAddress: addressesAndCollaterals.changeAddress,
-            usedAddresses: addressesAndCollaterals.usedAddresses,
-            collateralUTxOs: addressesAndCollaterals.collateralUTxOs,
-            stakeAddress: createContractRequest.stakeAddress,
-
-            contract: createContractRequest.contract,
-            threadRoleName: createContractRequest.threadRoleName,
-            roles: createContractRequest.roles,
-
-            tags: createContractRequest.tags,
-            metadata: createContractRequest.metadata,
-            minimumLovelaceUTxODeposit:
-              createContractRequest.minimumLovelaceUTxODeposit,
-          })
-        )
-      ),
-      TE.chainW(
-        (buildCreateContractTxResponse: BuildCreateContractTxResponse) =>
-          pipe(
-            tryCatchDefault(() =>
-              wallet.signTx(buildCreateContractTxResponse.tx.cborHex)
-            ),
-            TE.chain((hexTransactionWitnessSet) =>
-              tryCatchDefault(() =>
-                client.submitContract(
-                  buildCreateContractTxResponse.contractId,
-                  transactionWitnessSetTextEnvelope(hexTransactionWitnessSet)
-                )
-              )
-            ),
-            TE.map(() => buildCreateContractTxResponse.contractId)
-          )
-      ),
-      TE.map((contractId) => [contractId, contractIdToTxId(contractId)])
-    );
-
-export const createContractFpTs: (
-  client: RestClient
-) => (
-  wallet: WalletAPI
-) => (
-  createContractRequest: CreateContractRequest
-) => TE.TaskEither<Error | DecodingError, ContractId> =
-  (client) => (wallet) => (createContractRequest) =>
-    pipe(
-      submitCreateTxFpTs(client)(wallet)(createContractRequest),
-      TE.chainW(([contractId, txId]) =>
-        tryCatchDefault(() =>
-          wallet.waitConfirmation(txId).then((_) => contractId)
-        )
-      )
-    );
 
 export const applyInputsTxFpTs: (
   client: FPTSRestAPI

--- a/packages/runtime/lifecycle/test/examples/swap.ada.token.e2e.spec.ts
+++ b/packages/runtime/lifecycle/test/examples/swap.ada.token.e2e.spec.ts
@@ -21,7 +21,7 @@ import {
   logDebug,
   logInfo,
   logWalletInfo,
-  readEnvConfigurationFile,
+  readTestConfiguration,
   mkTestEnvironment,
   logError,
 } from "@marlowe.io/testing-kit";
@@ -41,8 +41,8 @@ describe("swap", () => {
     "can execute the nominal case",
     async () => {
       try {
-        const { bank, runtime, participants } =
-          await readEnvConfigurationFile().then(
+        const { bank, mkLifecycle, participants } =
+          await readTestConfiguration().then(
             mkTestEnvironment({
               seller: {
                 walletSeedPhrase: generateSeedPhrase("24-words"),
@@ -65,6 +65,9 @@ describe("swap", () => {
 
         await logWalletInfo("seller", seller.wallet);
         await logWalletInfo("buyer", buyer.wallet);
+        const sellerLifecycle = mkLifecycle(seller.wallet);
+        const buyerLifecycle = mkLifecycle(buyer.wallet);
+        const bankLifecycle = mkLifecycle(bank);
 
         const scheme: AtomicSwap.Scheme = {
           offer: {
@@ -92,9 +95,9 @@ describe("swap", () => {
         logInfo("Contract Creation");
         const openroleCOnfig = mintRole("OpenRole");
         logInfo(`Config ${MarloweJSON.stringify(openroleCOnfig, null, 4)}`);
-        const [contractId, txCreatedContract] = await runtime
-          .mkLifecycle(seller.wallet)
-          .contracts.createContract({
+
+        const [contractId, txCreatedContract] =
+          await sellerLifecycle.contracts.createContract({
             contract: swapContract,
             minimumLovelaceUTxODeposit: 3_000_000,
             roles: {
@@ -104,14 +107,13 @@ describe("swap", () => {
         logInfo("Contract Created");
         await seller.wallet.waitConfirmation(txCreatedContract);
         await seller.wallet.waitRuntimeSyncingTillCurrentWalletTip(
-          runtime.client
+          sellerLifecycle.restClient
         );
 
         logInfo(`Seller > Provision Offer`);
 
         let actions = await getAvailableActions(
-          runtime.client,
-          runtime.mkLifecycle(seller.wallet),
+          sellerLifecycle,
           scheme,
           contractId
         );
@@ -119,22 +121,22 @@ describe("swap", () => {
         expect(actions.length).toBe(1);
         expect(actions[0].typeName).toBe("ProvisionOffer");
         const provisionOffer = actions[0] as AtomicSwap.ProvisionOffer;
-        const offerProvisionedTx = await runtime
-          .mkLifecycle(seller.wallet)
-          .contracts.applyInputs(contractId, {
+        const offerProvisionedTx = await sellerLifecycle.contracts.applyInputs(
+          contractId,
+          {
             inputs: [provisionOffer.input],
-          });
+          }
+        );
 
         await seller.wallet.waitConfirmation(offerProvisionedTx);
         await seller.wallet.waitRuntimeSyncingTillCurrentWalletTip(
-          runtime.client
+          sellerLifecycle.restClient
         );
 
         logInfo(`Buyer > Swap`);
 
         actions = await getAvailableActions(
-          runtime.client,
-          runtime.mkLifecycle(seller.wallet),
+          sellerLifecycle,
           scheme,
           contractId
         );
@@ -143,37 +145,35 @@ describe("swap", () => {
         expect(actions[0].typeName).toBe("Swap");
         expect(actions[1].typeName).toBe("Retract");
         const swap = actions[0] as AtomicSwap.Swap;
-        const swappedTx = await runtime
-          .mkLifecycle(buyer.wallet)
-          .contracts.applyInputs(contractId, { inputs: [swap.input] });
+        const swappedTx = await buyerLifecycle.contracts.applyInputs(
+          contractId,
+          { inputs: [swap.input] }
+        );
 
         await buyer.wallet.waitConfirmation(swappedTx);
         await buyer.wallet.waitRuntimeSyncingTillCurrentWalletTip(
-          runtime.client
+          buyerLifecycle.restClient
         );
 
         logInfo(`Anyone > Confirm Swap`);
 
-        actions = await getAvailableActions(
-          runtime.client,
-          runtime.mkLifecycle(bank),
-          scheme,
-          contractId
-        );
+        actions = await getAvailableActions(bankLifecycle, scheme, contractId);
 
         expect(actions.length).toBe(1);
         expect(actions[0].typeName).toBe("ConfirmSwap");
         const confirmSwap = actions[0] as AtomicSwap.ConfirmSwap;
-        const swapConfirmedTx = await runtime
-          .mkLifecycle(bank)
-          .contracts.applyInputs(contractId, { inputs: [confirmSwap.input] });
+        const swapConfirmedTx = await bankLifecycle.contracts.applyInputs(
+          contractId,
+          { inputs: [confirmSwap.input] }
+        );
 
         await bank.waitConfirmation(swapConfirmedTx);
-        await bank.waitRuntimeSyncingTillCurrentWalletTip(runtime.client);
+        await bank.waitRuntimeSyncingTillCurrentWalletTip(
+          bankLifecycle.restClient
+        );
 
         const closedState = await getClosedState(
-          runtime.client,
-          runtime.mkLifecycle(bank),
+          bankLifecycle,
           scheme,
           contractId
         );
@@ -182,13 +182,11 @@ describe("swap", () => {
 
         logInfo(`Buyer > Retrieve Payout`);
 
-        const buyerPayouts = await runtime
-          .mkLifecycle(buyer.wallet)
-          .payouts.available(onlyByContractIds([contractId]));
+        const buyerPayouts = await buyerLifecycle.payouts.available(
+          onlyByContractIds([contractId])
+        );
         expect(buyerPayouts.length).toBe(1);
-        await runtime
-          .mkLifecycle(buyer.wallet)
-          .payouts.withdraw([buyerPayouts[0].payoutId]);
+        await buyerLifecycle.payouts.withdraw([buyerPayouts[0].payoutId]);
 
         await logWalletInfo("seller", seller.wallet);
         await logWalletInfo("buyer", buyer.wallet);
@@ -212,7 +210,6 @@ describe("swap", () => {
 });
 
 const getClosedState = async (
-  runtimeClient: RestClient,
   runtimeLifecycle: RuntimeLifecycle,
   scheme: AtomicSwap.Scheme,
   contractId: ContractId
@@ -220,13 +217,12 @@ const getClosedState = async (
   const inputHistory =
     await runtimeLifecycle.contracts.getInputHistory(contractId);
 
-  await shouldBeAClosedContract(runtimeClient, contractId);
+  await shouldBeAClosedContract(runtimeLifecycle.restClient, contractId);
 
   return AtomicSwap.getClosedState(scheme, inputHistory);
 };
 
 const getAvailableActions = async (
-  runtimeClient: RestClient,
   runtimeLifecycle: RuntimeLifecycle,
   scheme: AtomicSwap.Scheme,
   contractId: ContractId
@@ -235,7 +231,7 @@ const getAvailableActions = async (
     await runtimeLifecycle.contracts.getInputHistory(contractId);
 
   const marloweState = await getMarloweStatefromAnActiveContract(
-    runtimeClient,
+    runtimeLifecycle.restClient,
     contractId
   );
   const contractState = AtomicSwap.getActiveState(

--- a/packages/testing-kit/src/environment/configuration.ts
+++ b/packages/testing-kit/src/environment/configuration.ts
@@ -1,117 +1,61 @@
-import { Network, NetworkGuard, getNetwork } from "@marlowe.io/runtime-core";
-import { formatValidationErrors } from "jsonbigint-io-ts-reporters";
-import { unsafeEither } from "@marlowe.io/adapter/fp-ts";
-import * as E from "fp-ts/lib/Either.js";
-import { Blockfrost } from "lucid-cardano";
-import { SeedPhrase, seedPhrase } from "../wallet/seedPhrase.js";
-import {
-  RestClient,
-  mkRestClient,
-  RuntimeVersion,
-} from "@marlowe.io/runtime-rest-client";
-import * as Lucid from "lucid-cardano";
-import * as G from "@marlowe.io/runtime-rest-client/guards";
-import { MarloweJSON } from "@marlowe.io/adapter/codec";
+import * as t from "io-ts/lib/index.js";
+import { readFile } from "fs/promises";
+import * as fs from "fs";
+import * as path from "path";
+const lucidNetworkGuard = t.union([
+  t.literal("Mainnet"),
+  t.literal("Preview"),
+  t.literal("Preprod"),
+  t.literal("Custom"),
+]);
 
-/**
- * Test Configuration : Read from an env file, it contains :
- * 1. The necessary configuration to run e2e tests over a Lucid Wallet and a Runtime.
- * 2. A Bank Wallet Seed Phrase to provision ephemeral Test Wallets
- */
-export type TestConfiguration = {
-  bank: { seedPhrase: SeedPhrase };
-  lucid: { blockfrost: Blockfrost; node: { network: Lucid.Network } };
-  runtime: {
-    version: RuntimeVersion;
-    url: URL;
-    client: RestClient;
-    node: { network: Network };
-  };
-};
+const testConfigurationGuard = t.type({
+  bank: t.type({ seedPhrase: t.string }),
+  lucid: t.type({
+    blockfrostProjectId: t.string,
+    blockfrostUrl: t.string,
+  }),
+  network: lucidNetworkGuard,
+  runtimeURL: t.string,
+});
 
+export type TestConfiguration = t.TypeOf<typeof testConfigurationGuard>;
+
+function findRootDir(currentDir: string): string | null {
+  // Check if a tsconfig.json file exists in the current directory
+  const tsconfigPath = path.join(currentDir, "tsconfig-base.json");
+  if (fs.existsSync(tsconfigPath)) {
+    return currentDir;
+  }
+
+  // If not, go up one level
+  const parentDir = path.dirname(currentDir);
+
+  // Check if we have reached the root directory
+  if (parentDir === currentDir) {
+    return null; // Root not found
+  }
+
+  // Recursive call to find root directory in the parent directory
+  return findRootDir(parentDir);
+}
+
+// Get the root directory of the TypeScript project
+const rootDir = findRootDir(process.cwd());
 /**
  * Read Test Configurations from an env file
  * @returns
  */
-export const readEnvConfigurationFile =
-  async (): Promise<TestConfiguration> => {
-    const runtimeURL = readEnvRuntimeURL();
-    const lucidNetwork = readEnvLucidNodeNetwork();
-    const runtimeClient = mkRestClient(runtimeURL.toString());
-    const status = await runtimeClient.healthcheck();
-    const runtimeNodeNetwork = getNetwork(status.networkId);
-
-    if (!G.CompatibleRuntimeVersion.is(status.version)) {
-      throw {
-        message: "Runtime Version is not Compatible with the ts-sdk",
-        details: MarloweJSON.stringify(status),
-      };
-    }
-
-    const configuration = {
-      bank: { seedPhrase: readEnvBankSeedPhrase() },
-      lucid: {
-        blockfrost: readEnvBlockfrost(),
-        node: { network: toLucidNetwork(lucidNetwork) },
-      },
-      runtime: {
-        version: status.version,
-        url: runtimeURL,
-        client: mkRestClient(runtimeURL.toString()),
-        node: { network: runtimeNodeNetwork },
-      },
-    };
-    return configuration;
-  };
-
-const readEnvBlockfrost = (): Blockfrost => {
-  const { BLOCKFROST_URL, BLOCKFROST_PROJECT_ID } = process.env;
-  if (BLOCKFROST_URL == undefined)
-    throw "Test environment variable not defined (BLOCKFROST_URL)";
-  if (BLOCKFROST_PROJECT_ID == undefined)
-    throw "Test environment variable not defined (BLOCKFROST_PROJECT_ID)";
-  return new Blockfrost(BLOCKFROST_URL, BLOCKFROST_PROJECT_ID);
-};
-
-const readEnvLucidNodeNetwork = (): Network => {
-  const { NETWORK_NAME } = process.env;
-  if (NETWORK_NAME == undefined)
-    throw "Test environment variable not defined (NETWORK_NAME) ";
-  return unsafeEither(
-    E.mapLeft(formatValidationErrors)(NetworkGuard.decode(NETWORK_NAME))
-  );
-};
-
-const readEnvBankSeedPhrase = (): SeedPhrase => {
-  const { BANK_SEED_PHRASE } = process.env;
-  if (BANK_SEED_PHRASE !== undefined) {
-    return seedPhrase(JSON.parse(BANK_SEED_PHRASE));
-  } else {
-    throw "environment configurations not available (BANK_PK_HEX)";
+export async function readTestConfiguration(
+  filepath?: string
+): Promise<TestConfiguration> {
+  if (!filepath) {
+    filepath = `${rootDir}/env/.test-env.json`;
   }
-};
-
-const readEnvRuntimeURL = () => {
-  const { MARLOWE_WEB_SERVER_URL } = process.env;
-  if (MARLOWE_WEB_SERVER_URL == undefined)
-    throw "environment configurations not available(MARLOWE_WEB_SERVER_URL)";
-  return new URL(MARLOWE_WEB_SERVER_URL);
-};
-
-/**
- * Convert a Marlowe Network Model to a Lucid one.
- * @param network
- * @returns
- */
-const toLucidNetwork = (network: Network): Lucid.Network => {
-  switch (network) {
-    case "private":
-      return "Custom";
-    case "preview":
-      return "Preview";
-    case "preprod":
-      return "Preprod";
-    case "mainnet":
-      return "Mainnet";
+  const configStr = await readFile(filepath, { encoding: "utf-8" });
+  const result = testConfigurationGuard.decode(JSON.parse(configStr));
+  if (result._tag === "Left") {
+    throw new Error("Invalid configuration");
   }
-};
+  return result.right;
+}

--- a/packages/testing-kit/src/environment/configuration.ts
+++ b/packages/testing-kit/src/environment/configuration.ts
@@ -9,7 +9,7 @@ const lucidNetworkGuard = t.union([
   t.literal("Custom"),
 ]);
 
-const testConfigurationGuard = t.type({
+export const testConfigurationGuard = t.type({
   bank: t.type({ seedPhrase: t.string }),
   lucid: t.type({
     blockfrostProjectId: t.string,

--- a/packages/testing-kit/src/environment/index.ts
+++ b/packages/testing-kit/src/environment/index.ts
@@ -1,7 +1,7 @@
-import { mkRuntimeLifecycle } from "@marlowe.io/runtime-lifecycle/generic";
-import { RestClient, mkFPTSRestClient } from "@marlowe.io/runtime-rest-client";
+import { mkRuntimeLifecycle } from "@marlowe.io/runtime-lifecycle";
+import { mkRestClient } from "@marlowe.io/runtime-rest-client";
 
-import { Lucid } from "lucid-cardano";
+import { Lucid, Blockfrost } from "lucid-cardano";
 
 import { RuntimeLifecycle } from "@marlowe.io/runtime-lifecycle/api";
 import { Assets } from "@marlowe.io/runtime-core";
@@ -28,10 +28,7 @@ export type TestEnvironment = {
   /**
    * Access to runtime client and the runtime lifecycle api
    */
-  runtime: {
-    client: RestClient;
-    mkLifecycle: (wallet: WalletTestAPI) => RuntimeLifecycle;
-  };
+  mkLifecycle: (wallet: WalletTestAPI) => RuntimeLifecycle;
 };
 
 /**
@@ -61,16 +58,15 @@ export const mkTestEnvironment =
   async (testConfiguration: TestConfiguration): Promise<TestEnvironment> => {
     logInfo("Test Environment : Initiating");
 
-    const deprecatedRestAPI = mkFPTSRestClient(
-      testConfiguration.runtime.url.toString()
-    );
-
     const bankLucid = await Lucid.new(
-      testConfiguration.lucid.blockfrost,
-      testConfiguration.lucid.node.network
+      new Blockfrost(
+        testConfiguration.lucid.blockfrostUrl,
+        testConfiguration.lucid.blockfrostProjectId
+      ),
+      testConfiguration.network
     );
 
-    bankLucid.selectWalletFromSeed(testConfiguration.bank.seedPhrase.join(" "));
+    bankLucid.selectWalletFromSeed(testConfiguration.bank.seedPhrase);
 
     const bank = mkLucidWalletTest(bankLucid);
 
@@ -82,23 +78,18 @@ export const mkTestEnvironment =
     }
     logInfo("Bank is provisionned enough");
     const participants = await bank.provision(provisionRequest);
-
     await bank.waitRuntimeSyncingTillCurrentWalletTip(
-      testConfiguration.runtime.client
+      mkRestClient(testConfiguration.runtimeURL)
     );
 
     logInfo("Test Environment : Ready");
     return {
       bank,
       participants: participants,
-      runtime: {
-        client: testConfiguration.runtime.client,
-        mkLifecycle: (wallet: WalletTestAPI) =>
-          mkRuntimeLifecycle(
-            deprecatedRestAPI,
-            testConfiguration.runtime.client,
-            wallet
-          ),
-      },
+      mkLifecycle: (wallet: WalletTestAPI) =>
+        mkRuntimeLifecycle({
+          runtimeURL: testConfiguration.runtimeURL,
+          wallet,
+        }),
     };
   };

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,23 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/adapter/src" },
+    { "path": "./packages/language/core/v1/src" },
+    { "path": "./packages/language/examples/src" },
+    { "path": "./packages/language/specification-client/src" },
+    { "path": "./packages/wallet/src" },
+    { "path": "./packages/runtime/client/rest/src" },
+    { "path": "./packages/runtime/core/src" },
+    { "path": "./packages/runtime/lifecycle/src" },
+    { "path": "./packages/token-metadata-client/src" },
+    { "path": "./packages/marlowe-object/src" },
+    { "path": "./examples/nodejs/src" },
+    { "path": "./packages/testing-kit/src" },
+
+    { "path": "./packages/runtime/lifecycle/test" },
+    { "path": "./packages/runtime/client/rest/test" },
+    { "path": "./packages/language/core/v1/test" },
+    { "path": "./packages/language/examples/test" },
+    { "path": "./packages/wallet/test" }
+  ]
+}


### PR DESCRIPTION
This PR modifies the `runtimeLifecycle.contracts.createContract` method to support bundles in a non-breaking way.

Additionaly I also modified the e2e test configuration to be able to debug it. 
For the moment to debug e2e tests you need to build (recommended with watch mode) in one terminal

```bash
$ tsc --build tsconfig.test.json --watch
```

Open up a VSCode Debug Terminal and execute

```bash
$ node --experimental-vm-modules node_modules/.bin/jest \
 --testRegex ".*e2e.spec.js$" \
 --runInBand \
 --modulePaths $(pwd)/packages/runtime/lifecycle/test-dist
```

That should attach the debugging session correctly with the source maps. In a future PR I'll modify the launch configuration to simplify this even further.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration for test environments.
  - Added support for creating contracts from contract bundles.
  - Enhanced contract creation workflow with additional request options.

- **Improvements**
  - Streamlined the contract and payout retrieval process with a new REST client.

- **Refactor**
  - Reorganized environment configuration to use JSON format.
  - Updated test setup to use new configuration and client creation methods.

- **Documentation**
  - Updated development guide to reflect changes in the environment setup process.

- **Bug Fixes**
  - Fixed an issue where contract creation was not properly handling different request types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->