### PR TITLE
[fix] ContractAPI.getApplicable was returning noNext when a Contract is Active

### DIFF
--- a/packages/runtime/lifecycle/src/generic/contracts.ts
+++ b/packages/runtime/lifecycle/src/generic/contracts.ts
@@ -128,7 +128,7 @@ const getApplicableInputs =
     const contractDetails = await unsafeTaskEither(
       deprecatedRestAPI.contracts.contract.get(contractId)
     );
-    if (contractDetails.state) {
+    if (!contractDetails.state) {
       return noNext;
     } else {
       const parties = await getParties(wallet)(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic for contract state evaluation to enhance decision-making flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->