### PR TITLE
Atomic swap/unit tests (part of PLT-9226)

### DIFF
--- a/changelog.d/20240117_103735_nicolas.henin.md
+++ b/changelog.d/20240117_103735_nicolas.henin.md
@@ -1,0 +1,6 @@
+### @marlowe.io/language-examples
+
+- Breaking Change(Atomic Swap Contract) : Renamed "NotNotifiedOnTime" to "SwappedButNotNotifiedOnTime" ([PR-175](https://github.com/input-output-hk/marlowe-ts-sdk/pull/175))
+- Test(Atomic Swap Contract) : Added Unit Tests ([PR-175](https://github.com/input-output-hk/marlowe-ts-sdk/pull/175))
+
+

--- a/packages/adapter/src/io-ts.ts
+++ b/packages/adapter/src/io-ts.ts
@@ -78,9 +78,9 @@ export function convertNullableToUndefined<C extends t.Mixed>(
 }
 /**
  * Convert an unknown value to `T` if the guard provided is validating the unknown value.
- * @param guard 
- * @param aValue 
- * @returns 
+ * @param guard
+ * @param aValue
+ * @returns
  */
 export function expectType<T>(guard: t.Type<T>, aValue: unknown): T {
   if (guard.is(aValue)) {

--- a/packages/adapter/src/io-ts.ts
+++ b/packages/adapter/src/io-ts.ts
@@ -1,5 +1,6 @@
 import * as t from "io-ts/lib/index.js";
 import { withValidate } from "io-ts-types";
+import { MarloweJSON } from "./codec.js";
 /**
  * In the TS-SDK we duplicate the type and guard definition for each type as the
  * inferred type from io-ts does not produce a good type export when used with
@@ -74,4 +75,19 @@ export function convertNullableToUndefined<C extends t.Mixed>(
     (u, c) => (u == null ? t.success(undefined) : codec.validate(u, c)),
     name
   );
+}
+/**
+ * Convert an unknown value to `T` if the guard provided is validating the unknown value.
+ * @param guard 
+ * @param aValue 
+ * @returns 
+ */
+export function expectType<T>(guard: t.Type<T>, aValue: unknown): T {
+  if (guard.is(aValue)) {
+    return aValue;
+  } else {
+    throw `Expected value from type ${
+      guard.name
+    } but got ${MarloweJSON.stringify(aValue, null, 4)} `;
+  }
 }

--- a/packages/language/core/v1/src/semantics.ts
+++ b/packages/language/core/v1/src/semantics.ts
@@ -5,7 +5,7 @@
 import * as G from "@marlowe.io/language-core-v1/guards";
 import { datetoTimeout } from "@marlowe.io/language-core-v1";
 import { playTrace } from "@marlowe.io/language-core-v1/semantics";
-import { Role, lovelace } from "@marlowe.io/language-core-v1/playground-v1";
+import { role, lovelace } from "@marlowe.io/language-core-v1/playground-v1";
 import { escrow } from "@marlowe.io/language-examples";
 
 const contract = escrow({
@@ -24,15 +24,15 @@ const txs = [
     },
     tx_inputs: [
       {
-        input_from_party: Role("Buyer"),
+        input_from_party: role("Buyer"),
         that_deposits: 100n,
         of_token: lovelace,
-        into_account: Role("Seller"),
+        into_account: role("Seller"),
       },
       {
         for_choice_id: {
           choice_name: "Everything is alright",
-          choice_owner: Role("Buyer"),
+          choice_owner: role("Buyer"),
         },
         input_that_chooses_num: 0n,
       },

--- a/packages/language/examples/test/atomicSwap.spec.ts
+++ b/packages/language/examples/test/atomicSwap.spec.ts
@@ -1,0 +1,553 @@
+import { AtomicSwap } from "@marlowe.io/language-examples";
+import * as G from "@marlowe.io/language-core-v1/guards";
+import { MarloweJSON } from "@marlowe.io/adapter/codec";
+
+import {
+  datetoTimeout,
+  close,
+  Party,
+  Payee,
+  Input,
+} from "@marlowe.io/language-core-v1";
+import {
+  TransactionSuccess,
+  emptyState,
+  playTrace,
+} from "@marlowe.io/language-core-v1/semantics";
+import {
+  ConfirmSwap,
+  ProvisionOffer,
+  Retract,
+  Swap,
+  getActiveState,
+  getAvailableActions,
+  getClosedState,
+  waitingForAnswer,
+  waitingForSwapConfirmation,
+  waitingSellerOffer,
+} from "../src/atomicSwap.js";
+import * as t from "io-ts/lib/index.js";
+
+const aDeadlineInThePast = datetoTimeout(new Date("2000-05-01"));
+const contractStart = datetoTimeout(new Date("2000-05-02"));
+const aGivenNow = datetoTimeout(new Date("2000-05-04"));
+const aTxInterval = {
+  from: datetoTimeout(new Date("2000-05-03")),
+  to: datetoTimeout(new Date("2000-05-05")),
+};
+const aDeadlineInTheFuture = datetoTimeout(new Date("2000-05-06"));
+const aGivenNowAfterDeadline = datetoTimeout(new Date("2000-05-07"));
+
+const anAsset = {
+  amount: 1n,
+  token: { currency_symbol: "aCurrency", token_name: "sellerToken" },
+};
+const anotherAsset = {
+  amount: 2n,
+  token: { currency_symbol: "aCurrency", token_name: "buyerToken" },
+};
+
+describe("Atomic Swap", () => {
+  describe("is active (on 4 different states)", () => {
+    it("when waiting a seller offer - WaitingSellerOffer", () => {
+      // Set up
+      const scheme: AtomicSwap.Scheme = {
+        offer: {
+          seller: { address: "sellerAddress" },
+          deadline: aDeadlineInTheFuture,
+          asset: anAsset,
+        },
+        ask: {
+          buyer: { role_token: "buyer" },
+          deadline: aDeadlineInTheFuture,
+          asset: anotherAsset,
+        },
+        swapConfirmation: {
+          deadline: aDeadlineInTheFuture,
+        },
+      };
+      const inputFlow: Input[] = [];
+
+      // Execute
+
+      const contract = AtomicSwap.mkContract(scheme);
+      const state = emptyState(3_000_000n);
+
+      // Verify
+
+      const activeState = getActiveState(
+        scheme,
+        aGivenNow,
+        inputFlow.map((input) => ({ interval: aTxInterval, input: input })),
+        state
+      );
+      expect(activeState.typeName).toBe("WaitingSellerOffer");
+    });
+    it("when no seller offer have been provided in time - NoSellerOfferInTime", () => {
+      // Set up
+      const scheme: AtomicSwap.Scheme = {
+        offer: {
+          seller: { address: "sellerAddress" },
+          deadline: aDeadlineInTheFuture,
+          asset: anAsset,
+        },
+        ask: {
+          buyer: { role_token: "buyer" },
+          deadline: aDeadlineInTheFuture,
+          asset: anotherAsset,
+        },
+        swapConfirmation: {
+          deadline: aDeadlineInTheFuture,
+        },
+      };
+      const inputFlow: Input[] = [];
+
+      // Execute
+
+      const contract = AtomicSwap.mkContract(scheme);
+      const state = emptyState(3_000_000n);
+
+      // Verify
+
+      const activeState = getActiveState(
+        scheme,
+        aGivenNowAfterDeadline,
+        inputFlow.map((input) => ({ interval: aTxInterval, input: input })),
+        state
+      );
+      expect(activeState.typeName).toBe("NoSellerOfferInTime");
+    });
+    it("when waiting a for an answer - WaitingForAnswer", () => {
+      // Set up
+      const scheme: AtomicSwap.Scheme = {
+        offer: {
+          seller: { address: "sellerAddress" },
+          deadline: aDeadlineInTheFuture,
+          asset: anAsset,
+        },
+        ask: {
+          buyer: { role_token: "buyer" },
+          deadline: aDeadlineInTheFuture,
+          asset: anotherAsset,
+        },
+        swapConfirmation: {
+          deadline: aDeadlineInTheFuture,
+        },
+      };
+      const inputFlow: Input[] = [
+        (getAvailableActions(scheme, waitingSellerOffer)[0] as ProvisionOffer)
+          .input,
+      ];
+
+      // Execute
+
+      const { contract, state, payments, warnings } =
+        expectType<TransactionSuccess>(
+          G.TransactionSuccess,
+          playTrace(contractStart, AtomicSwap.mkContract(scheme), [
+            {
+              tx_interval: aTxInterval,
+              tx_inputs: inputFlow,
+            },
+          ])
+        );
+
+      // Verify
+
+      expect(warnings).toStrictEqual([]);
+      expect(contract).not.toBe(close);
+      expect(payments).toStrictEqual([]);
+
+      const activeState = getActiveState(
+        scheme,
+        aGivenNow,
+        inputFlow.map((input) => ({ interval: aTxInterval, input: input })),
+        state
+      );
+      expect(activeState.typeName).toBe("WaitingForAnswer");
+    });
+    it("when waiting a for a swap confirmation (Open Role requirement to prevent double-satisfaction attacks) - WaitingForSwapConfirmation", () => {
+      // Set up
+      const scheme: AtomicSwap.Scheme = {
+        offer: {
+          seller: { address: "sellerAddress" },
+          deadline: aDeadlineInTheFuture,
+          asset: anAsset,
+        },
+        ask: {
+          buyer: { role_token: "buyer" },
+          deadline: aDeadlineInTheFuture,
+          asset: anotherAsset,
+        },
+        swapConfirmation: {
+          deadline: aDeadlineInTheFuture,
+        },
+      };
+      const inputFlow: Input[] = [
+        (getAvailableActions(scheme, waitingSellerOffer)[0] as ProvisionOffer)
+          .input,
+        (getAvailableActions(scheme, waitingForAnswer)[0] as Swap).input,
+      ];
+
+      // Execute
+
+      const { contract, state, payments, warnings } =
+        expectType<TransactionSuccess>(
+          G.TransactionSuccess,
+          playTrace(contractStart, AtomicSwap.mkContract(scheme), [
+            {
+              tx_interval: aTxInterval,
+              tx_inputs: inputFlow,
+            },
+          ])
+        );
+
+      // Verify
+      const expectedPayments = [
+        {
+          payment_from: scheme.offer.seller,
+          to: payeeAccount(scheme.ask.buyer),
+          amount: scheme.offer.asset.amount,
+          token: scheme.offer.asset.token,
+        },
+        {
+          payment_from: scheme.ask.buyer,
+          to: payeeAccount(scheme.offer.seller),
+          amount: scheme.ask.asset.amount,
+          token: scheme.ask.asset.token,
+        },
+      ];
+      expect(warnings).toStrictEqual([]);
+      expect(contract).not.toBe(close);
+      expect(payments).toStrictEqual(expectedPayments);
+
+      const activeState = getActiveState(
+        scheme,
+        aGivenNow,
+        inputFlow.map((input) => ({ interval: aTxInterval, input: input })),
+        state
+      );
+      expect(activeState.typeName).toBe("WaitingForSwapConfirmation");
+    });
+  });
+  describe("is closed (with 5 closed reasons)", () => {
+    it("when tokens have been swapped - Swapped", () => {
+      // Set up
+      const scheme: AtomicSwap.Scheme = {
+        offer: {
+          seller: { address: "sellerAddress" },
+          deadline: aDeadlineInTheFuture,
+          asset: anAsset,
+        },
+        ask: {
+          buyer: { role_token: "buyer" },
+          deadline: aDeadlineInTheFuture,
+          asset: anotherAsset,
+        },
+        swapConfirmation: {
+          deadline: aDeadlineInTheFuture,
+        },
+      };
+      const inputFlow = [
+        (getAvailableActions(scheme, waitingSellerOffer)[0] as ProvisionOffer)
+          .input,
+        (getAvailableActions(scheme, waitingForAnswer)[0] as Swap).input,
+        (
+          getAvailableActions(
+            scheme,
+            waitingForSwapConfirmation
+          )[0] as ConfirmSwap
+        ).input,
+      ];
+
+      // Execute
+
+      const { contract, payments, warnings } = expectType<TransactionSuccess>(
+        G.TransactionSuccess,
+        playTrace(contractStart, AtomicSwap.mkContract(scheme), [
+          {
+            tx_interval: aTxInterval,
+            tx_inputs: inputFlow,
+          },
+        ])
+      );
+
+      // Verify
+
+      const expectedPayments = [
+        {
+          payment_from: scheme.offer.seller,
+          to: payeeAccount(scheme.ask.buyer),
+          amount: scheme.offer.asset.amount,
+          token: scheme.offer.asset.token,
+        },
+        {
+          payment_from: scheme.ask.buyer,
+          to: payeeAccount(scheme.offer.seller),
+          amount: scheme.ask.asset.amount,
+          token: scheme.ask.asset.token,
+        },
+        {
+          payment_from: scheme.offer.seller,
+          to: payeeParty(scheme.offer.seller),
+          amount: scheme.ask.asset.amount,
+          token: scheme.ask.asset.token,
+        },
+        {
+          payment_from: scheme.ask.buyer,
+          to: payeeParty(scheme.ask.buyer),
+          amount: scheme.offer.asset.amount,
+          token: scheme.offer.asset.token,
+        },
+      ];
+      expect(warnings).toStrictEqual([]);
+      expect(contract).toBe(close);
+      expect(payments).toStrictEqual(expectedPayments);
+
+      const state = getClosedState(
+        scheme,
+        inputFlow.map((input) => ({ interval: aTxInterval, input: input }))
+      );
+      expect(state.reason.typeName).toBe("Swapped");
+    });
+    it("when tokens have been swapped but nobody has confirmed the swap on time (Open Role requirement to prevent double-satisfaction attacks) - SwappedButNotNotifiedOnTime", () => {
+      // Set up
+      const scheme: AtomicSwap.Scheme = {
+        offer: {
+          seller: { address: "sellerAddress" },
+          deadline: aDeadlineInTheFuture,
+          asset: anAsset,
+        },
+        ask: {
+          buyer: { role_token: "buyer" },
+          deadline: aDeadlineInTheFuture,
+          asset: anotherAsset,
+        },
+        swapConfirmation: {
+          deadline: aDeadlineInThePast,
+        },
+      };
+      const inputFlow = [
+        (getAvailableActions(scheme, waitingSellerOffer)[0] as ProvisionOffer)
+          .input,
+        (getAvailableActions(scheme, waitingForAnswer)[0] as Swap).input,
+      ];
+
+      // Execute
+
+      const { contract, payments, warnings } = expectType<TransactionSuccess>(
+        G.TransactionSuccess,
+        playTrace(contractStart, AtomicSwap.mkContract(scheme), [
+          {
+            tx_interval: aTxInterval,
+            tx_inputs: inputFlow,
+          },
+        ])
+      );
+
+      // Verify
+
+      const expectedPayments = [
+        {
+          payment_from: scheme.offer.seller,
+          to: payeeAccount(scheme.ask.buyer),
+          amount: scheme.offer.asset.amount,
+          token: scheme.offer.asset.token,
+        },
+        {
+          payment_from: scheme.ask.buyer,
+          to: payeeAccount(scheme.offer.seller),
+          amount: scheme.ask.asset.amount,
+          token: scheme.ask.asset.token,
+        },
+        {
+          payment_from: scheme.offer.seller,
+          to: payeeParty(scheme.offer.seller),
+          amount: scheme.ask.asset.amount,
+          token: scheme.ask.asset.token,
+        },
+        {
+          payment_from: scheme.ask.buyer,
+          to: payeeParty(scheme.ask.buyer),
+          amount: scheme.offer.asset.amount,
+          token: scheme.offer.asset.token,
+        },
+      ];
+
+      expect(warnings).toStrictEqual([]);
+      expect(contract).toBe(close);
+      expect(payments).toStrictEqual(expectedPayments);
+
+      const state = getClosedState(
+        scheme,
+        inputFlow.map((input) => ({ interval: aTxInterval, input: input }))
+      );
+      expect(state.reason.typeName).toBe("SwappedButNotNotifiedOnTime");
+    });
+    it("when no buyer has answered to the offer on time - NotAnsweredOnTime", () => {
+      // Set up
+      const scheme: AtomicSwap.Scheme = {
+        offer: {
+          seller: { address: "sellerAddress" },
+          deadline: aDeadlineInTheFuture,
+          asset: anAsset,
+        },
+        ask: {
+          buyer: { role_token: "buyer" },
+          deadline: aDeadlineInThePast,
+          asset: anotherAsset,
+        },
+        swapConfirmation: {
+          deadline: aDeadlineInTheFuture,
+        },
+      };
+      const inputFlow = [
+        (getAvailableActions(scheme, waitingSellerOffer)[0] as ProvisionOffer)
+          .input,
+      ];
+
+      // Execute
+
+      const { contract, payments, warnings } = expectType<TransactionSuccess>(
+        G.TransactionSuccess,
+        playTrace(contractStart, AtomicSwap.mkContract(scheme), [
+          {
+            tx_interval: aTxInterval,
+            tx_inputs: inputFlow,
+          },
+        ])
+      );
+
+      // Verify
+
+      const expectedPayments = [
+        {
+          payment_from: scheme.offer.seller,
+          to: payeeParty(scheme.offer.seller),
+          amount: scheme.offer.asset.amount,
+          token: scheme.offer.asset.token,
+        },
+      ];
+      expect(warnings).toStrictEqual([]);
+      expect(contract).toBe(close);
+      expect(payments).toStrictEqual(expectedPayments);
+
+      const state = getClosedState(
+        scheme,
+        inputFlow.map((input) => ({ interval: aTxInterval, input: input }))
+      );
+      expect(state.reason.typeName).toBe("NotAnsweredOnTime");
+    });
+    it("when the seller has retracted - SellerRetracted", () => {
+      // Set up
+      const scheme: AtomicSwap.Scheme = {
+        offer: {
+          seller: { address: "sellerAddress" },
+          deadline: aDeadlineInTheFuture,
+          asset: anAsset,
+        },
+        ask: {
+          buyer: { role_token: "buyer" },
+          deadline: aDeadlineInTheFuture,
+          asset: anotherAsset,
+        },
+        swapConfirmation: {
+          deadline: aDeadlineInTheFuture,
+        },
+      };
+      const inputFlow = [
+        (getAvailableActions(scheme, waitingSellerOffer)[0] as ProvisionOffer)
+          .input,
+        (getAvailableActions(scheme, waitingForAnswer)[1] as Retract).input,
+      ];
+
+      // Execute
+
+      const { contract, payments, warnings } = expectType<TransactionSuccess>(
+        G.TransactionSuccess,
+        playTrace(contractStart, AtomicSwap.mkContract(scheme), [
+          {
+            tx_interval: aTxInterval,
+            tx_inputs: inputFlow,
+          },
+        ])
+      );
+
+      // Verify
+
+      const expectedPayments = [
+        {
+          payment_from: scheme.offer.seller,
+          to: payeeParty(scheme.offer.seller),
+          amount: scheme.offer.asset.amount,
+          token: scheme.offer.asset.token,
+        },
+      ];
+      expect(warnings).toStrictEqual([]);
+      expect(contract).toBe(close);
+      expect(payments).toStrictEqual(expectedPayments);
+
+      const state = getClosedState(
+        scheme,
+        inputFlow.map((input) => ({ interval: aTxInterval, input: input }))
+      );
+      expect(state.reason.typeName).toBe("SellerRetracted");
+    });
+    it("when the seller has not provisioned the contract on time and advance is applied - NoOfferProvisionnedOnTime", () => {
+      // Set up
+      const scheme: AtomicSwap.Scheme = {
+        offer: {
+          seller: { address: "sellerAddress" },
+          deadline: aDeadlineInThePast,
+          asset: anAsset,
+        },
+        ask: {
+          buyer: { role_token: "buyer" },
+          deadline: aDeadlineInTheFuture,
+          asset: anotherAsset,
+        },
+        swapConfirmation: {
+          deadline: aDeadlineInTheFuture,
+        },
+      };
+      const advance: Input[] = [];
+
+      // Execute
+
+      const { contract, payments, warnings } = expectType<TransactionSuccess>(
+        G.TransactionSuccess,
+        playTrace(contractStart, AtomicSwap.mkContract(scheme), [
+          {
+            tx_interval: aTxInterval,
+            tx_inputs: advance,
+          },
+        ])
+      );
+
+      // Verify
+
+      expect(warnings).toStrictEqual([]);
+      expect(contract).toBe(close);
+      expect(payments).toStrictEqual([]);
+
+      const state = getClosedState(
+        scheme,
+        advance.map((input) => ({ interval: aTxInterval, input: input }))
+      );
+      expect(state.reason.typeName).toBe("NoOfferProvisionnedOnTime");
+    });
+  });
+});
+
+function expectType<T>(guard: t.Type<T>, aValue: unknown): T {
+  if (guard.is(aValue)) {
+    return aValue;
+  } else {
+    throw `Expected value from type ${
+      guard.name
+    } but got ${MarloweJSON.stringify(aValue, null, 4)} `;
+  }
+}
+
+const payeeAccount = (party: Party): Payee => ({ account: party });
+const payeeParty = (party: Party): Payee => ({ party: party });

--- a/packages/language/examples/test/atomicSwap.spec.ts
+++ b/packages/language/examples/test/atomicSwap.spec.ts
@@ -141,16 +141,15 @@ describe("Atomic Swap", () => {
 
       // Execute
 
-      const { contract, state, payments, warnings } =
-        expectType<TransactionSuccess>(
-          G.TransactionSuccess,
-          playTrace(contractStart, AtomicSwap.mkContract(scheme), [
-            {
-              tx_interval: aTxInterval,
-              tx_inputs: inputFlow,
-            },
-          ])
-        );
+      const { contract, state, payments, warnings } = expectType(
+        G.TransactionSuccess,
+        playTrace(contractStart, AtomicSwap.mkContract(scheme), [
+          {
+            tx_interval: aTxInterval,
+            tx_inputs: inputFlow,
+          },
+        ])
+      );
 
       // Verify
 
@@ -191,16 +190,15 @@ describe("Atomic Swap", () => {
 
       // Execute
 
-      const { contract, state, payments, warnings } =
-        expectType<TransactionSuccess>(
-          G.TransactionSuccess,
-          playTrace(contractStart, AtomicSwap.mkContract(scheme), [
-            {
-              tx_interval: aTxInterval,
-              tx_inputs: inputFlow,
-            },
-          ])
-        );
+      const { contract, state, payments, warnings } = expectType(
+        G.TransactionSuccess,
+        playTrace(contractStart, AtomicSwap.mkContract(scheme), [
+          {
+            tx_interval: aTxInterval,
+            tx_inputs: inputFlow,
+          },
+        ])
+      );
 
       // Verify
       const expectedPayments = [
@@ -262,7 +260,7 @@ describe("Atomic Swap", () => {
 
       // Execute
 
-      const { contract, payments, warnings } = expectType<TransactionSuccess>(
+      const { contract, payments, warnings } = expectType(
         G.TransactionSuccess,
         playTrace(contractStart, AtomicSwap.mkContract(scheme), [
           {
@@ -335,7 +333,7 @@ describe("Atomic Swap", () => {
 
       // Execute
 
-      const { contract, payments, warnings } = expectType<TransactionSuccess>(
+      const { contract, payments, warnings } = expectType(
         G.TransactionSuccess,
         playTrace(contractStart, AtomicSwap.mkContract(scheme), [
           {
@@ -408,7 +406,7 @@ describe("Atomic Swap", () => {
 
       // Execute
 
-      const { contract, payments, warnings } = expectType<TransactionSuccess>(
+      const { contract, payments, warnings } = expectType(
         G.TransactionSuccess,
         playTrace(contractStart, AtomicSwap.mkContract(scheme), [
           {
@@ -463,7 +461,7 @@ describe("Atomic Swap", () => {
 
       // Execute
 
-      const { contract, payments, warnings } = expectType<TransactionSuccess>(
+      const { contract, payments, warnings } = expectType(
         G.TransactionSuccess,
         playTrace(contractStart, AtomicSwap.mkContract(scheme), [
           {
@@ -514,7 +512,7 @@ describe("Atomic Swap", () => {
 
       // Execute
 
-      const { contract, payments, warnings } = expectType<TransactionSuccess>(
+      const { contract, payments, warnings } = expectType(
         G.TransactionSuccess,
         playTrace(contractStart, AtomicSwap.mkContract(scheme), [
           {

--- a/packages/language/examples/test/atomicSwap.spec.ts
+++ b/packages/language/examples/test/atomicSwap.spec.ts
@@ -1,6 +1,6 @@
 import { AtomicSwap } from "@marlowe.io/language-examples";
 import * as G from "@marlowe.io/language-core-v1/guards";
-import { MarloweJSON } from "@marlowe.io/adapter/codec";
+import { expectType } from "@marlowe.io/adapter/io-ts";
 
 import {
   datetoTimeout,
@@ -71,7 +71,7 @@ describe("Atomic Swap", () => {
       // Execute
 
       const contract = AtomicSwap.mkContract(scheme);
-      const state = emptyState(3_000_000n);
+      const state = emptyState(aDeadlineInThePast);
 
       // Verify
 
@@ -105,7 +105,7 @@ describe("Atomic Swap", () => {
       // Execute
 
       const contract = AtomicSwap.mkContract(scheme);
-      const state = emptyState(3_000_000n);
+      const state = emptyState(aDeadlineInThePast);
 
       // Verify
 
@@ -538,16 +538,6 @@ describe("Atomic Swap", () => {
     });
   });
 });
-
-function expectType<T>(guard: t.Type<T>, aValue: unknown): T {
-  if (guard.is(aValue)) {
-    return aValue;
-  } else {
-    throw `Expected value from type ${
-      guard.name
-    } but got ${MarloweJSON.stringify(aValue, null, 4)} `;
-  }
-}
 
 const payeeAccount = (party: Party): Payee => ({ account: party });
 const payeeParty = (party: Party): Payee => ({ party: party });


### PR DESCRIPTION
as the last part of #147 , this PR adds to the Atomic Swap Contract in `@marlowe.io/language-examples` the following unit tests : 
```
 Atomic Swap
    is active (on 4 different states)
      ✓ when waiting a seller offer - WaitingSellerOffer (2 ms)
      ✓ when no seller offer have been provided in time - NoSellerOfferInTime
      ✓ when waiting a for an answer - WaitingForAnswer (5 ms)
      ✓ when waiting a for a swap confirmation (Open Role requirement to prevent double-satisfaction attacks) - WaitingForSwapConfirmation (2 ms)
    is closed (with 5 closed reasons)
      ✓ when tokens have been swapped - Swapped (2 ms)
      ✓ when tokens have been swapped but nobody has confirmed the swap on time (Open Role requirement to prevent double-satisfaction attacks) - SwappedButNotConfirmedOnTime (2 ms)
      ✓ when no buyer has answered to the offer on time - NotAnsweredOnTime (1 ms)
      ✓ when the seller has retracted - SellerRetracted (1 ms)
      ✓ when the seller has not provisioned the contract on time and advance is applied - NoOfferProvisionnedOnTime (1 ms)
``` 
this PR will close #147 and the milestone as well.

N.B : a closed reason have been renamed from "NotNotifiedOnTime" to "SwappedBuNotNotifiedOnTime" to express that even if  the "notify" has not been applied, the time out will provoke the swap payment. 

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced unit tests for Atomic Swap Contract functionality.
  - Added the `expectType` function for improved type validation in SDK.

- **Breaking Changes**
  - Renamed "NotNotifiedOnTime" to "SwappedButNotNotifiedOnTime" in Atomic Swap Contract.

- **Refactor**
  - Updated usage of `Role` to `role` in semantics affecting input and account control logic.

- **Bug Fixes**
  - Fixed Atomic Swap Contract states and conditions handling for more accurate swap process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->