### PR TITLE
Bump IOGX 2024-01-17

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2044,11 +2044,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_3"
       },
       "locked": {
-        "lastModified": 1705504491,
-        "narHash": "sha256-SyEeZtxmMVJi3icxFecjG2ayXSEzFg6Sfr1OSIcoA4c=",
+        "lastModified": 1705512869,
+        "narHash": "sha256-Ao8jH8+l+0Og5Ce54xCDpyYJWIHKyMnVm7Geynb4JTU=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "82ffa7e4a2b2a7e080688847b1e1de1b006a8e63",
+        "rev": "3568c382d72e5da710792a2a65902ca224dc0162",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2044,11 +2044,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_3"
       },
       "locked": {
-        "lastModified": 1705568517,
-        "narHash": "sha256-c6kmj500OHK7WB8bpkTiE9/NVgMXTH5byrVMDCTONeo=",
+        "lastModified": 1705569277,
+        "narHash": "sha256-lxOEkRiTovWkOp0KmQ4b/zXzgNaRXOuSDw32AGqeNDo=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "f182168310b81b311b400204249cce52dcedd764",
+        "rev": "f76a5a6552f9a6eedb627bca71bbcd62d44161fe",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2044,16 +2044,15 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_3"
       },
       "locked": {
-        "lastModified": 1705569277,
-        "narHash": "sha256-lxOEkRiTovWkOp0KmQ4b/zXzgNaRXOuSDw32AGqeNDo=",
+        "lastModified": 1705571486,
+        "narHash": "sha256-W5K64oz4UzHeoOxaedJrVRtbSSa8P5wcaU45ZASzplE=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "f76a5a6552f9a6eedb627bca71bbcd62d44161fe",
+        "rev": "6eb8822d6e12d1c88b2bf0280b405df0eebe7fe6",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "custom-precommit-hooks",
         "repo": "iogx",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2044,15 +2044,16 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_3"
       },
       "locked": {
-        "lastModified": 1704784299,
-        "narHash": "sha256-XTrqO1NODi0v+d6eVlCKQ18aJ2HPh5fM0TRlaNhPt9U=",
+        "lastModified": 1705504491,
+        "narHash": "sha256-SyEeZtxmMVJi3icxFecjG2ayXSEzFg6Sfr1OSIcoA4c=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "d8f80745ccbb4983265494fafd7e0e20d4740351",
+        "rev": "82ffa7e4a2b2a7e080688847b1e1de1b006a8e63",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "custom-precommit-hooks",
         "repo": "iogx",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2044,11 +2044,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_3"
       },
       "locked": {
-        "lastModified": 1705512869,
-        "narHash": "sha256-Ao8jH8+l+0Og5Ce54xCDpyYJWIHKyMnVm7Geynb4JTU=",
+        "lastModified": 1705568517,
+        "narHash": "sha256-c6kmj500OHK7WB8bpkTiE9/NVgMXTH5byrVMDCTONeo=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "3568c382d72e5da710792a2a65902ca224dc0162",
+        "rev": "f182168310b81b311b400204249cce52dcedd764",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Marlowe ts-sdk";
 
   inputs = {
-    iogx.url = "github:input-output-hk/iogx";
+    iogx.url = "github:input-output-hk/iogx?ref=custom-precommit-hooks";
     marlowe-spec.url = "github:input-output-hk/marlowe";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Marlowe ts-sdk";
 
   inputs = {
-    iogx.url = "github:input-output-hk/iogx?ref=custom-precommit-hooks";
+    iogx.url = "github:input-output-hk/iogx";
     marlowe-spec.url = "github:input-output-hk/marlowe";
   };
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -53,17 +53,7 @@ lib.iogx.mkShell {
     prettier.enable = true;
     prettier.extraOptions = "--plugin ${pkgs.nodePackages.prettier-plugin-toml}/lib/node_modules/prettier-plugin-toml/lib/api.js --write";
     prettier.excludes = [ "jsdelivr-npm-importmap\\.js" ];
-    prettier.include = [
-      "css"
-      "html"
-      "js"
-      "json"
-      "jsx"
-      "scss"
-      "ts"
-      "yaml"
-      "toml"
-    ];
+    prettier.files = "\\.(css|html|js|json|jsx|scss|ts|yaml|toml)";
   };
 }
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -53,7 +53,7 @@ lib.iogx.mkShell {
     prettier.enable = true;
     prettier.extraOptions = "--plugin ${pkgs.nodePackages.prettier-plugin-toml}/lib/node_modules/prettier-plugin-toml/lib/api.js --write";
     prettier.excludes = [ "jsdelivr-npm-importmap\\.js" ];
-    prettier.files = "\\.(css|html|js|json|jsx|scss|ts|yaml|toml)";
+    prettier.files = "\\.(css|html|js|json|jsx|scss|ts|yaml|toml)$";
   };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Modified the URL for the `iogx` input in the `flake.nix` file to include a reference to custom pre-commit hooks.
	- Changed the `prettier.include` setting to `prettier.files` in the `shell.nix` file, altering the way files are included for Prettier formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->