### PR TITLE
fixed test build

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc --version && tsc --build && shx mkdir -p dist && rollup --config rollup/config.mjs",
     "clean": "npm run clean --workspaces && shx rm -rf dist",
-    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --config ./jest.unit.config.js --verbose",
+    "test": "tsc --build tsconfig.test.json && NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --config ./jest.unit.config.js --verbose",
     "test:e2e": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' jest --runInBand --config ./jest.e2e.config.js --verbose",
     "docs": "typedoc . --treatWarningsAsErrors --options ./typedoc.json",
     "serve": "ws --port 1337 --rewrite '/importmap -> https://cdn.jsdelivr.net/gh/input-output-hk/marlowe-ts-sdk@0.3.0-beta/jsdelivr-npm-importmap.js'",

--- a/packages/runtime/client/rest/test/endpoints/contracts.spec.e2e.ts
+++ b/packages/runtime/client/rest/test/endpoints/contracts.spec.e2e.ts
@@ -58,7 +58,7 @@ describe("contracts endpoints", () => {
 
       await Promise.all(
         firstPage.contracts.map((contract) =>
-          restClient.getContractById(contract.contractId)
+          restClient.getContractById({ contractId: contract.contractId })
         )
       );
     },

--- a/packages/runtime/lifecycle/test/generic/contracts.e2e.spec.ts
+++ b/packages/runtime/lifecycle/test/generic/contracts.e2e.spec.ts
@@ -63,7 +63,7 @@ describe("Runtime Contract Lifecycle ", () => {
           await bank.waitConfirmation(txIdContractCreated);
           logInfo(
             `contractID status : ${contractId} -> ${
-              (await runtime.restClient.getContractById(contractId)).status
+              (await runtime.restClient.getContractById({ contractId })).status
             }`
           );
           await bank.waitRuntimeSyncingTillCurrentWalletTip(runtime.restClient);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the approach for passing `contractId` in end-to-end tests for more consistent contract retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->