### PR TITLE
Fix how the ContractId and TxId branded types are printed in the documentation

### DIFF
--- a/changelog.d/20240222_130945_hrajchert_fix_branded_output.md
+++ b/changelog.d/20240222_130945_hrajchert_fix_branded_output.md
@@ -1,0 +1,5 @@
+### @marlowe.io/runtime-core
+
+- Fix: Branding of ContractId and TxId ([PR-185](https://github.com/input-output-hk/marlowe-ts-sdk/pull/185))
+
+

--- a/packages/runtime/client/rest/src/contract/transaction/details.ts
+++ b/packages/runtime/client/rest/src/contract/transaction/details.ts
@@ -23,6 +23,7 @@ import {
   BlockHeader,
   ContractIdGuard,
   TextEnvelope,
+  TxIdGuard,
 } from "@marlowe.io/runtime-core";
 import { TxStatus } from "./status.js";
 import { assertGuardEqual, proxy } from "@marlowe.io/adapter/io-ts";
@@ -97,7 +98,7 @@ export const TransactionDetailsGuard = assertGuardEqual(
   proxy<TransactionDetails>(),
   t.type({
     contractId: ContractIdGuard,
-    transactionId: TxId,
+    transactionId: TxIdGuard,
     continuations: optionFromNullable(G.BuiltinByteString),
     tags: TagsGuard,
     metadata: MetadataGuard,
@@ -108,7 +109,7 @@ export const TransactionDetailsGuard = assertGuardEqual(
     outputUtxo: optionFromNullable(TxOutRef),
     outputContract: optionFromNullable(G.Contract),
     outputState: optionFromNullable(G.MarloweState),
-    consumingTx: optionFromNullable(TxId),
+    consumingTx: optionFromNullable(TxIdGuard),
     invalidBefore: ISO8601,
     invalidHereafter: ISO8601,
     txBody: optionFromNullable(TextEnvelopeGuard),

--- a/packages/runtime/client/rest/src/contract/transaction/endpoints/collection.ts
+++ b/packages/runtime/client/rest/src/contract/transaction/endpoints/collection.ts
@@ -27,6 +27,7 @@ import {
   unTxOutRef,
   ContractId,
   ContractIdGuard,
+  TxIdGuard,
 } from "@marlowe.io/runtime-core";
 import { TxHeader, TxHeaderGuard } from "../header.js";
 import { assertGuardEqual, proxy } from "@marlowe.io/adapter/io-ts";
@@ -125,7 +126,7 @@ export const GetTransactionsForContractResponseGuard = assertGuardEqual(
 export type TransactionTextEnvelope = t.TypeOf<typeof TransactionTextEnvelope>;
 export const TransactionTextEnvelope = t.type({
   contractId: ContractIdGuard,
-  transactionId: TxId,
+  transactionId: TxIdGuard,
   tx: TextEnvelopeGuard,
 });
 

--- a/packages/runtime/client/rest/src/contract/transaction/endpoints/singleton.ts
+++ b/packages/runtime/client/rest/src/contract/transaction/endpoints/singleton.ts
@@ -14,6 +14,7 @@ import {
   HexTransactionWitnessSet,
   HexTransactionWitnessSetGuard,
   TxId,
+  TxIdGuard,
   transactionWitnessSetTextEnvelope,
 } from "@marlowe.io/runtime-core";
 
@@ -45,7 +46,7 @@ export const GetContractTransactionByIdRequestGuard = assertGuardEqual(
   proxy<GetContractTransactionByIdRequest>(),
   t.type({
     contractId: ContractIdGuard,
-    txId: TxId,
+    txId: TxIdGuard,
   })
 );
 
@@ -80,7 +81,7 @@ export const SubmitContractTransactionRequestGuard = assertGuardEqual(
   proxy<SubmitContractTransactionRequest>(),
   t.type({
     contractId: ContractIdGuard,
-    transactionId: TxId,
+    transactionId: TxIdGuard,
     hexTransactionWitnessSet: HexTransactionWitnessSetGuard,
   })
 );

--- a/packages/runtime/client/rest/src/contract/transaction/header.ts
+++ b/packages/runtime/client/rest/src/contract/transaction/header.ts
@@ -14,6 +14,7 @@ import {
   TxOutRef,
   TxId,
   ContractId,
+  TxIdGuard,
 } from "@marlowe.io/runtime-core";
 import { TxStatus } from "./status.js";
 import { BuiltinByteString } from "@marlowe.io/language-core-v1";
@@ -46,7 +47,7 @@ export interface TxHeader {
  */
 export const TxHeaderGuard = t.type({
   contractId: ContractIdGuard,
-  transactionId: TxId,
+  transactionId: TxIdGuard,
   continuations: optionFromNullable(G.BuiltinByteString),
   tags: TagsGuard,
   metadata: MetadataGuard,

--- a/packages/runtime/core/src/contract/id.ts
+++ b/packages/runtime/core/src/contract/id.ts
@@ -2,7 +2,7 @@ import * as t from "io-ts/lib/index.js";
 import { split } from "fp-ts/lib/string.js";
 import { pipe } from "fp-ts/lib/function.js";
 import { head } from "fp-ts/lib/ReadonlyNonEmptyArray.js";
-import { TxId } from "../tx/id.js";
+import { TxId, txId } from "../tx/id.js";
 import { unsafeEither } from "@marlowe.io/adapter/fp-ts";
 import { preservedBrand } from "@marlowe.io/adapter/io-ts";
 
@@ -16,11 +16,17 @@ export const ContractIdGuard = preservedBrand(
   "ContractId"
 );
 
-export type ContractId = t.TypeOf<typeof ContractIdGuard>;
+/**
+ * Marlowe contract identifier.
+ *
+ * @remarks The underlying data structure is a normal string, but in the type
+ * level it is **Branded** with a unique symbol so that it is not confused with other strings
+ */
+export type ContractId = t.Branded<string, ContractIdBrand>;
 
 export const contractId = (s: string) =>
   unsafeEither(ContractIdGuard.decode(s));
 
 export const contractIdToTxId: (contractId: ContractId) => TxId = (
   contractId
-) => pipe(contractId, split("#"), head);
+) => pipe(contractId, split("#"), head, txId);

--- a/packages/runtime/core/src/payout/index.ts
+++ b/packages/runtime/core/src/payout/index.ts
@@ -4,7 +4,7 @@ import { fromNewtype } from "io-ts-types";
 import { split } from "fp-ts/lib/string.js";
 import { pipe } from "fp-ts/lib/function.js";
 import { head } from "fp-ts/lib/ReadonlyNonEmptyArray.js";
-import { TxId } from "../tx/id.js";
+import { txId, TxId } from "../tx/id.js";
 import { ContractIdGuard } from "../contract/id.js";
 import { AssetId, Assets } from "../asset/index.js";
 
@@ -15,7 +15,7 @@ export const unPayoutId = iso<PayoutId>().unwrap;
 export const payoutId = iso<PayoutId>().wrap;
 
 export const payoutIdToTxId: (payoutId: PayoutId) => TxId = (payoutId) =>
-  pipe(payoutId, unPayoutId, split("#"), head);
+  pipe(payoutId, unPayoutId, split("#"), head, txId);
 
 export type WithdrawalId = Newtype<
   { readonly WithdrawalId: unique symbol },
@@ -27,7 +27,7 @@ export const withdrawalId = iso<WithdrawalId>().wrap;
 
 export const withdrawalIdToTxId: (withdrawalId: WithdrawalId) => TxId = (
   withdrawalId
-) => pipe(withdrawalId, unWithdrawalId);
+) => pipe(withdrawalId, unWithdrawalId, txId);
 
 // DISCUSSION: PayoutAvailable or AvailablePayout?
 export type PayoutAvailable = t.TypeOf<typeof PayoutAvailable>;

--- a/packages/runtime/core/src/tx/id.ts
+++ b/packages/runtime/core/src/tx/id.ts
@@ -1,6 +1,22 @@
+import { unsafeEither } from "@marlowe.io/adapter/fp-ts";
 import * as t from "io-ts/lib/index.js";
 
-// TODO: Try to make newtype as this gets replaced to string
-//       in the docs.
-export type TxId = t.TypeOf<typeof TxId>;
-export const TxId = t.string; // to refine
+export interface TxIdBrand {
+  readonly TxId: unique symbol;
+}
+
+/**
+ * Cardano transaction identifier.
+ *
+ * @remarks The underlying data structure is a normal string, but in the type
+ * level it is **Branded** with a unique symbol so that it is not confused with other strings
+ */
+export type TxId = t.Branded<string, TxIdBrand>;
+
+export const TxIdGuard = t.brand(
+  t.string,
+  (s): s is t.Branded<string, TxIdBrand> => true,
+  "TxId"
+);
+
+export const txId = (s: string) => unsafeEither(TxIdGuard.decode(s));

--- a/typedoc.json
+++ b/typedoc.json
@@ -24,6 +24,9 @@
     "fp-ts": {
       "Option": "https://gcanti.github.io/fp-ts/modules/Option.ts.html"
     },
+    "io-ts": {
+      "Branded": "https://github.com/gcanti/io-ts/blob/master/index.md#branded-types--refinements"
+    },
     "lucid-cardano": {
       "Lucid": "https://deno.land/x/lucid@0.10.7/mod.ts?s=Lucid"
     },


### PR DESCRIPTION
In the [PR#184](https://github.com/input-output-hk/marlowe-ts-sdk/pull/184) I added the [preserveBrand](https://github.com/input-output-hk/marlowe-ts-sdk/pull/184/files#diff-e0dd2397b30ada803aa20302f71c1e7d3b0dad965de1ae262d8c3f60296db024R153) function that helped with the uses of branded types inside recursive data types, but the typing was a [little bit off](https://github.com/gcanti/io-ts/issues/604#issuecomment-1959706880), and it changed the generated documentation from this 
![Screenshot 2024-02-22 at 12 59 17](https://github.com/input-output-hk/marlowe-ts-sdk/assets/2634059/9415966d-905f-4222-bb5e-b3a4379fa246)

to this
<img width="923" alt="Screenshot 2024-02-22 at 10 46 51" src="https://github.com/input-output-hk/marlowe-ts-sdk/assets/2634059/45ca516b-604d-4180-bc2e-170ec69e9fdb">

This PR:
* fixes that issue
* creates a branded type for TxId
 
and moreover it improves the generated output to this:

<img width="967" alt="Screenshot 2024-02-22 at 12 49 01" src="https://github.com/input-output-hk/marlowe-ts-sdk/assets/2634059/1381ad06-aa68-415d-abc7-1bde7d174261">

Note that in order to preserve the type alias (at least in typescript version 4.9.5) we need to define ContractId like this

```ts
export type ContractId = t.Branded<string, ContractIdBrand>;
```

instead of 

```ts
export type ContractId = t.TypeOf<typeof ContractIdGuard>;
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated function signatures and type usage across multiple files for enhanced type safety and consistency.
- **New Features**
	- Introduced branded types and guards (`TxIdGuard`, `ContractIdBrand`, `TxIdBrand`) to ensure more robust type checking and validation.
- **Bug Fixes**
	- Fixed inconsistencies in type usage for transaction IDs across the application, aligning them with the new type guards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->